### PR TITLE
chore: updates release-please output variable reference

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,11 +18,11 @@ jobs:
         with:
           release-type: node
       - uses: actions/checkout@v4
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.release_created }}
         with:
           fetch-depth: 100
       - name: Deploy Prod
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.release_created }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com


### PR DESCRIPTION
Release please changed the output variable name, so it is deploying main to prod currently.