### PR TITLE
chore: Bump pnpm to 11.5.1 and migrate overrides config

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,12 +84,7 @@
     "urql": "5.0.1",
     "xstate": "5.30.0"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
-  "pnpm": {
-    "overrides": {
-      "brace-expansion": "^2.0.1"
-    }
-  },
+  "packageManager": "pnpm@11.5.1+sha512.93f7b57422ea7068257235b4c16eb60762eb68e1dc23723199cc739043ea9be2c4143274a399d8c6defa2b1176226d9ca1c4b63482d6200c1a8fbaa78c1d1485",
   "devDependencies": {
     "@serwist/turbopack": "^9.5.7",
     "@statelyai/inspect": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
         version: 0.28.0
       serwist:
         specifier: ^9.5.7
-        version: 9.5.7(browserslist@4.28.1)(typescript@6.0.2)
+        version: 9.5.7(browserslist@4.28.2)(typescript@6.0.2)
 
 packages:
 
@@ -2122,9 +2122,6 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
-
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -3341,6 +3338,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4565,6 +4563,10 @@ snapshots:
   '@serwist/utils@9.5.7(browserslist@4.28.1)':
     optionalDependencies:
       browserslist: 4.28.1
+
+  '@serwist/utils@9.5.7(browserslist@4.28.2)':
+    optionalDependencies:
+      browserslist: 4.28.2
 
   '@serwist/window@9.5.7(browserslist@4.28.1)(typescript@6.0.2)':
     dependencies:
@@ -6012,10 +6014,6 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
-
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -6562,7 +6560,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.0.2
 
   minimatch@9.0.9:
     dependencies:
@@ -6907,6 +6905,15 @@ snapshots:
   serwist@9.5.7(browserslist@4.28.1)(typescript@6.0.2):
     dependencies:
       '@serwist/utils': 9.5.7(browserslist@4.28.1)
+      idb: 8.0.3
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - browserslist
+
+  serwist@9.5.7(browserslist@4.28.2)(typescript@6.0.2):
+    dependencies:
+      '@serwist/utils': 9.5.7(browserslist@4.28.2)
       idb: 8.0.3
     optionalDependencies:
       typescript: 6.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
   - "functions"
   - "functions/_packages/*"
 sharedWorkspaceLockfile: false
+overrides:
+  brace-expansion: "^2.0.1"


### PR DESCRIPTION
## What changed

- Bump the pinned package manager from **pnpm 10.33.0 → 11.5.1** (`packageManager` field).
- Migrate the `brace-expansion` override from the `pnpm` field in `package.json` to **`pnpm-workspace.yaml`**, and remove the now-dead `pnpm` field.
- Refresh `pnpm-lock.yaml`.

## Why

The production build was failing because `@fontsource/inter` could not be resolved — dependencies weren't installing cleanly. Root cause was a toolchain mismatch (Node 20 + an incompatible pnpm). Installing under the project's pinned toolchain (Node 24.14.0) fixes the build.

While bumping pnpm to 11.5.1, pnpm warned that it **no longer reads the `pnpm` field in `package.json`**. That meant our `brace-expansion: "^2.0.1"` override was being silently ignored, which would allow the vulnerable 1.x line back into the dependency tree. Moving it to `pnpm-workspace.yaml` restores the override — verified that only `brace-expansion@2.0.2` resolves.

## Reviewer notes

- No application code changed — this is a tooling/lockfile change only.
- Requires Node ≥ 22.13 (project pins 24.14.0 via `.nvmrc`); pnpm 11 will refuse to run on older Node.
- Out of scope (pre-existing, not introduced here): `pnpm typecheck` fails on a TS 6.0 deprecation of `target: ES5` in the shared `@cellar-assistant/typescript-config/nextjs.json`. Worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)