### PR TITLE
fix: Bump Nhost functions Node runtime to 22 to fix deploy

### DIFF
--- a/nhost/nhost.toml
+++ b/nhost/nhost.toml
@@ -61,7 +61,7 @@ httpPoolSize = 100
 
 [functions]
 [functions.node]
-version = 20
+version = 22
 
 [auth]
 version = '0.50.1'


### PR DESCRIPTION
## What changed

Bumped `[functions.node] version` from `20` → `22` in `nhost/nhost.toml`.

## Why

The recent pnpm `10.33.0` → `11.5.1` bump (6a5847f4) broke the Nhost deploy at the **dependency-install** step:

```
TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.
    at Object.<anonymous> (/tmp/.corepack/v1/pnpm/11.5.1/bin/pnpm.cjs:3:1)
    at Module2._compile (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:16942:34)
Node.js v20.19.6
```

Nhost built functions on **Node 20**, whose old bundled corepack can't launch pnpm 11's bin script (`pnpm.cjs` uses a top-level dynamic `import()`). pnpm 10.x didn't trip this, which is why deploys worked until the bump. Local dev was unaffected because `.nvmrc` is Node 24.

Bumping the functions runtime to Node 22 selects a newer build toolchain whose corepack can run pnpm 11 — while keeping the pnpm 11 upgrade, the `brace-expansion` security override, and the `@fontsource/inter` Vercel fix from the original bump. Node 22 is a supported Nhost runtime and aligns the build toolchain with local dev.

## Reviewer notes

- Config-only change; no application code touched. Node 22 is backward-compatible with the functions deps (`@google/genai`, `express` 5, `@nhost/nhost-js` 4, etc.).
- After merge, confirm the Nhost deploy's "Installing dependencies (pnpm)" step fetches pnpm 11.5.1 and installs cleanly.
- Fallback if it still fails: revert `packageManager` to `pnpm@10.33.0` and restore the override in a pnpm-10-readable location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)