### PR TITLE
fix: generate vectors for sake items

### DIFF
--- a/functions/_packages/shared/gql/graphql.ts
+++ b/functions/_packages/shared/gql/graphql.ts
@@ -120,6 +120,7 @@ export type Wines = Record<string, unknown>; // Placeholder for GraphQL generate
 export type Spirits = Record<string, unknown>; // Placeholder for GraphQL generated type
 export type Coffees = Record<string, unknown>; // Placeholder for GraphQL generated type
 export type Teas = Record<string, unknown>; // Placeholder for GraphQL generated type
+export type Sakes = Record<string, unknown>; // Placeholder for GraphQL generated type
 export type Item_Vectors_Bool_Exp = Record<string, unknown>; // Placeholder for GraphQL generated type
 export type Beer_Defaults_Result = Record<string, unknown>; // Placeholder for GraphQL generated type
 export type Wine_Defaults_Result = Record<string, unknown>; // Placeholder for GraphQL generated type

--- a/functions/generateItemVector/_embedding-config.ts
+++ b/functions/generateItemVector/_embedding-config.ts
@@ -463,6 +463,64 @@ export const EMBEDDING_CONFIGS = {
 
     baseTerms: ["tea", "leaves", "brew", "infusion"],
   },
+
+  sakes: {
+    primaryFields: [
+      {
+        field: "name" as const,
+        weight: 10,
+        synonyms: ["sake", "nihonshu", "rice wine"],
+      },
+      {
+        field: "category" as const,
+        weight: 9,
+        synonyms: ["grade", "classification"],
+      },
+      { field: "type" as const, weight: 8 },
+    ],
+
+    enhancingFields: [
+      { field: "rice_variety" as const, weight: 6, synonyms: ["rice"] },
+      {
+        field: "polish_grade" as const,
+        weight: 5,
+        formatter: (grade: number) => [
+          `${grade}% polish`,
+          `seimaibuai ${grade}`,
+        ],
+      },
+      { field: "region" as const, weight: 7, synonyms: ["origin"] },
+      { field: "country" as const, weight: 6 },
+      { field: "description" as const, weight: 5 },
+    ],
+
+    // Category-specific keyword mappings (sake category values are plain text)
+    categoryKeywords: {
+      junmai: ["junmai", "pure rice", "full-bodied", "rich", "umami"],
+      honjozo: ["honjozo", "light", "easy drinking", "added alcohol"],
+      ginjo: ["ginjo", "fragrant", "fruity", "refined", "premium"],
+      daiginjo: [
+        "daiginjo",
+        "premium",
+        "highly polished",
+        "elegant",
+        "aromatic",
+      ],
+      junmai_ginjo: ["junmai ginjo", "pure rice", "fragrant", "premium"],
+      junmai_daiginjo: [
+        "junmai daiginjo",
+        "pure rice",
+        "highly polished",
+        "luxurious",
+      ],
+      nigori: ["nigori", "cloudy", "unfiltered", "creamy", "sweet"],
+      sparkling: ["sparkling sake", "effervescent", "bubbly", "fresh"],
+      nama: ["namazake", "unpasteurized", "fresh", "vibrant"],
+      koshu: ["koshu", "aged sake", "matured", "complex"],
+    } as const satisfies Record<string, readonly string[]>,
+
+    baseTerms: ["sake", "nihonshu", "rice wine", "japanese"],
+  },
 } as const;
 
 // Description keyword patterns organized by relevance to item types

--- a/functions/generateItemVector/_embedding-generator.ts
+++ b/functions/generateItemVector/_embedding-generator.ts
@@ -6,6 +6,7 @@
 import type {
   Beers,
   Coffees,
+  Sakes,
   Spirits,
   Teas,
   Wines,
@@ -25,7 +26,7 @@ import {
 } from "./_embedding-config";
 
 // Type-safe item union
-type AnyItem = Beers | Wines | Spirits | Coffees | Teas;
+type AnyItem = Beers | Wines | Spirits | Coffees | Teas | Sakes;
 
 /**
  * Generate rich, searchable embedding text from any item using schema-driven configuration
@@ -213,6 +214,21 @@ function addTypeSpecificKeywords(
           tea.category,
         ) as keyof typeof teaConfig.categoryKeywords;
         const keywords = teaConfig.categoryKeywords[categoryKey];
+        if (keywords) {
+          parts.push(...keywords);
+        }
+      }
+      break;
+    }
+
+    case "sakes": {
+      const sake = item as Sakes;
+      const sakeConfig = config as typeof EMBEDDING_CONFIGS.sakes;
+      if (sake.category && "categoryKeywords" in sakeConfig) {
+        const categoryKey = String(
+          sake.category,
+        ) as keyof typeof sakeConfig.categoryKeywords;
+        const keywords = sakeConfig.categoryKeywords[categoryKey];
         if (keywords) {
           parts.push(...keywords);
         }

--- a/functions/generateItemVector/_types.ts
+++ b/functions/generateItemVector/_types.ts
@@ -31,6 +31,7 @@ const INSERT_ITEM_VECTOR_MUTATION = graphql(`
     $spirit_id: String,
     $coffee_id: String,
     $tea_id: String,
+    $sake_id: String,
     $vector: vector,
     $embedding_text: String
   ) {
@@ -40,6 +41,7 @@ const INSERT_ITEM_VECTOR_MUTATION = graphql(`
       spirit_id: $spirit_id,
       coffee_id: $coffee_id,
       tea_id: $tea_id,
+      sake_id: $sake_id,
       vector: $vector,
       embedding_text: $embedding_text
     }) {
@@ -49,6 +51,7 @@ const INSERT_ITEM_VECTOR_MUTATION = graphql(`
       spirit_id
       coffee_id
       tea_id
+      sake_id
       vector
       embedding_text
       created_at
@@ -170,6 +173,30 @@ const GET_TEA_QUERY = graphql(`
   }
 `);
 
+const GET_SAKE_QUERY = graphql(`
+  query GetSake($id: uuid!) {
+    sakes_by_pk(id: $id) {
+      id
+      name
+      description
+      category
+      type
+      polish_grade
+      rice_variety
+      yeast_strain
+      sake_meter_value
+      acidity
+      amino_acid
+      alcohol_content_percentage
+      vintage
+      country
+      region
+      created_at
+      updated_at
+    }
+  }
+`);
+
 // =============================================================================
 // Extracted Types
 // =============================================================================
@@ -202,11 +229,18 @@ export type WineItem = ResultOf<typeof GET_WINE_QUERY>["wines_by_pk"];
 export type SpiritItem = ResultOf<typeof GET_SPIRIT_QUERY>["spirits_by_pk"];
 export type CoffeeItem = ResultOf<typeof GET_COFFEE_QUERY>["coffees_by_pk"];
 export type TeaItem = ResultOf<typeof GET_TEA_QUERY>["teas_by_pk"];
+export type SakeItem = ResultOf<typeof GET_SAKE_QUERY>["sakes_by_pk"];
 
 /**
  * Union type for all item types
  */
-export type ItemType = BeerItem | WineItem | SpiritItem | CoffeeItem | TeaItem;
+export type ItemType =
+  | BeerItem
+  | WineItem
+  | SpiritItem
+  | CoffeeItem
+  | TeaItem
+  | SakeItem;
 
 // =============================================================================
 // Function-specific Types
@@ -215,7 +249,13 @@ export type ItemType = BeerItem | WineItem | SpiritItem | CoffeeItem | TeaItem;
 /**
  * Valid table names for item vector generation
  */
-export type TableName = "beers" | "wines" | "spirits" | "coffees" | "teas";
+export type TableName =
+  | "beers"
+  | "wines"
+  | "spirits"
+  | "coffees"
+  | "teas"
+  | "sakes";
 
 /**
  * Webhook input structure for item vector generation
@@ -235,6 +275,7 @@ export interface ItemVectorsBoolExp {
   spirit_id?: { _eq?: string };
   coffee_id?: { _eq?: string };
   tea_id?: { _eq?: string };
+  sake_id?: { _eq?: string };
 }
 
 /**
@@ -258,7 +299,7 @@ export interface VectorGenerationContext {
 export function isValidTableName(value: unknown): value is TableName {
   return (
     typeof value === "string" &&
-    ["beers", "wines", "spirits", "coffees", "teas"].includes(value)
+    ["beers", "wines", "spirits", "coffees", "teas", "sakes"].includes(value)
   );
 }
 
@@ -376,11 +417,13 @@ export function createDeleteVectorWhereClause(
       return { ...where, coffee_id: { _eq: itemId } };
     case "teas":
       return { ...where, tea_id: { _eq: itemId } };
+    case "sakes":
+      return { ...where, sake_id: { _eq: itemId } };
     default:
       throw new FunctionValidationError(
         "generateItemVector",
         "tableName",
-        "must be one of: beers, wines, spirits, coffees, teas",
+        "must be one of: beers, wines, spirits, coffees, teas, sakes",
         type,
       );
   }

--- a/functions/generateItemVector/index.ts
+++ b/functions/generateItemVector/index.ts
@@ -90,12 +90,23 @@ const GET_TEA_IMAGE_QUERY = graphql(`
   }
 `);
 
+const GET_SAKE_IMAGE_QUERY = graphql(`
+  query GetSakeImage($itemId: uuid!) {
+    item_image(
+      where: { sake_id: { _eq: $itemId } }
+      order_by: { created_at: desc }
+      limit: 1
+    ) { file_id }
+  }
+`);
+
 const DISPLAY_IMAGE_QUERIES = {
   beers: GET_BEER_IMAGE_QUERY,
   wines: GET_WINE_IMAGE_QUERY,
   spirits: GET_SPIRIT_IMAGE_QUERY,
   coffees: GET_COFFEE_IMAGE_QUERY,
   teas: GET_TEA_IMAGE_QUERY,
+  sakes: GET_SAKE_IMAGE_QUERY,
 } as const;
 
 /**
@@ -254,6 +265,7 @@ async function processVectorGeneration(
         wine_id: name === "wines" ? String(item.id) : undefined,
         coffee_id: name === "coffees" ? String(item.id) : undefined,
         tea_id: name === "teas" ? String(item.id) : undefined,
+        sake_id: name === "sakes" ? String(item.id) : undefined,
         vector: JSON.stringify(embeddingResponse.embeddings),
       },
     },


### PR DESCRIPTION
## What

The `generate_sake_vector` event trigger ([`public_sakes.yaml`](nhost/metadata/databases/default/tables/public_sakes.yaml)) points its webhook at the `generateItemVector` function — but the function never recognized `"sakes"` as a valid table. `TableName`, `isValidTableName`, and the `createDeleteVectorWhereClause` switch all omitted it, so every sake insert/update fell through to the `default` branch and threw `FunctionValidationError("must be one of: beers, wines, spirits, coffees, teas")`.

This adds `"sakes"` everywhere `"teas"` is handled, mirroring it exactly.

## Why

Because vector generation threw on every sake, **sake items never got rows in `item_vectors`**, so sake menu-scan matching against the item vector store silently produced no matches. This is a pre-existing bug that predates the tea feature — tea was wired up correctly across all of these spots; sake was missed.

## Changes

- **`functions/generateItemVector/_types.ts`** — `TableName` union, `isValidTableName` array, `INSERT_ITEM_VECTOR_MUTATION` (`$sake_id` variable + field), new `GET_SAKE_QUERY` (uuid pk) + `SakeItem` type + `ItemType` union, `ItemVectorsBoolExp.sake_id`, and a `case "sakes"` in `createDeleteVectorWhereClause` (plus the error message).
- **`functions/generateItemVector/index.ts`** — new `GET_SAKE_IMAGE_QUERY` + `DISPLAY_IMAGE_QUERIES.sakes` entry (multimodal image fetch), and `sake_id` in the vector insert object.
- **`functions/generateItemVector/_embedding-config.ts`** — `sakes` `EMBEDDING_CONFIGS` entry. Required (not just nice-to-have): `TableName` flows into `ItemTypeKey` and `DISPLAY_IMAGE_QUERIES`, so adding `"sakes"` to the type without a matching config would break those lookups at compile time.
- **`functions/generateItemVector/_embedding-generator.ts`** — `Sakes` import, added to the `AnyItem` union, and a `case "sakes"` in `addTypeSpecificKeywords` (category keywords for junmai/ginjo/daiginjo/nigori/etc.).
- **`functions/_packages/shared/gql/graphql.ts`** — `Sakes` placeholder type (the shared shim had `Teas` but no `Sakes`).

## Notes for reviewers

- **No DB/metadata change needed** — `item_vectors.sake_id` already exists (migration `1758075726000_add_sake_tables`, plus the relationship + select permission in `public_item_vectors.yaml`). All `GET_SAKE_QUERY` fields match the `sakes` select-permission columns, and `select_by_pk` is in its query root.
- **Typecheck**: root and `functions/` package error counts unchanged vs. `main` (zero new errors). The remaining counts are the documented pre-existing baseline (gql.tada live-schema introspection, missing `next-env.d.ts`/`@/images`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)