### PR TITLE
fix: Migrate functions pnpm overrides/build config for pnpm 11 deploy

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -27,10 +27,5 @@
     "ollama": "0.6.3",
     "ramda": "0.32.0",
     "ts-pattern": "5.9.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "brace-expansion": "^2.0.1"
-    }
   }
 }

--- a/functions/pnpm-workspace.yaml
+++ b/functions/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+overrides:
+  brace-expansion: "^2.0.1"
+allowBuilds:
+  "@google/genai": false
+  protobufjs: false


### PR DESCRIPTION
Follow-up to #574 (the Node 22 bump). With Node 22, corepack now successfully runs pnpm 11 in the Nhost **functions** build — which surfaced two further pnpm-11 config regressions that fail the frozen install:

## 1. `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`

```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.overrides".
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation. The current "overrides" configuration doesn't match the value found in the lockfile
```

pnpm 11 no longer reads `pnpm.overrides` from `package.json`, but `functions/pnpm-lock.yaml` still records the `brace-expansion: ^2.0.1` override — so the standalone functions build mismatched. This mirrors the root migration already done in #558-era work: the override moves into `functions/pnpm-workspace.yaml`, and the dead `pnpm` field is removed from `functions/package.json`.

## 2. `ERR_PNPM_IGNORED_BUILDS`

pnpm 11 **fails** a frozen install when a dependency has an unapproved build script (`@google/genai`, `protobufjs`), instead of merely warning like pnpm 10. These scripts were already not executed on prior deploys, so they are explicitly denied via `allowBuilds` to preserve existing behavior.

## Verification

- `pnpm install --frozen-lockfile` in `functions/` (Node 24 / pnpm 11.5.1) now exits **0** — both the overrides check and the build-scripts check pass.
- Root workspace still resolves all members (`functions`, `functions/_packages/*`) cleanly; lockfiles unchanged.

`functions/pnpm-workspace.yaml`:
```yaml
overrides:
  brace-expansion: "^2.0.1"
allowBuilds:
  "@google/genai": false
  protobufjs: false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)