### PR TITLE
feat(ai): use gemini-3.5-flash for high quality tier

### DIFF
--- a/functions/_utils/ai-providers/vertex-ai.ts
+++ b/functions/_utils/ai-providers/vertex-ai.ts
@@ -161,7 +161,7 @@ export class VertexAIProvider implements AIProvider {
   private qualityModelMap: Record<ModelQuality, string> = {
     low: "gemini-3.1-flash-lite-preview",
     medium: "gemini-3.1-flash-lite-preview",
-    high: "gemini-3.1-pro-preview",
+    high: "gemini-3.5-flash",
   };
 
   // Map quality levels to Gemini 3 thinking levels


### PR DESCRIPTION
## What changed

Switches the Vertex AI **high** quality tier from `gemini-3.1-pro-preview` to the newly GA `gemini-3.5-flash` in [`functions/_utils/ai-providers/vertex-ai.ts`](functions/_utils/ai-providers/vertex-ai.ts).

```diff
  private qualityModelMap: Record<ModelQuality, string> = {
    low: "gemini-3.1-flash-lite-preview",
    medium: "gemini-3.1-flash-lite-preview",
-   high: "gemini-3.1-pro-preview",
+   high: "gemini-3.5-flash",
  };
```

## Why

`gemini-3.5-flash` (GA, released May 19 2026) is a better fit for the high tier than `gemini-3.1-pro-preview`:

| | input /M | output /M |
|---|---|---|
| `gemini-3.1-pro` (old) | $2.00 | $12.00 |
| `gemini-3.5-flash` (new) | **$1.50** | **$9.00** |

- **~25% cheaper** on both input and output tokens
- **Faster** inference
- Reportedly **matches or beats 3.1 Pro** on coding/agentic tasks

The `high` tier is consumed by `getItemDefaults` (bottle-label analysis) and `generateTierListInsights`.

## Reviewer notes

- **No endpoint change:** 3.5 Flash is Gemini 3 family, already covered by the factory's hardcoded `global` endpoint.
- **No thinking change:** existing `high → ThinkingLevel.MEDIUM` mapping carries over (3.5 Flash supports `thinkingConfig`).
- Model ID is the **stable/GA** string `gemini-3.5-flash` (no `-preview` suffix).
- `low`/`medium` tiers and embedding model (`gemini-embedding-2-preview`) are unchanged — both confirmed current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)