### PR TITLE
fix: move cellar edit button inline after name to avoid overlap

### DIFF
--- a/src/components/cellar/CellarCard.tsx
+++ b/src/components/cellar/CellarCard.tsx
@@ -62,38 +62,43 @@ export const CellarCard = ({
 }: CellarCardProps) => {
   return (
     <InteractiveCard sx={{ position: "relative" }}>
-      {canEdit(userId, cellar) && (
-        <Tooltip title="Edit Cellar">
-          <IconButton
-            size="sm"
-            variant="soft"
-            onClick={() => onEditClick(cellar.id)}
-            sx={{
-              position: "absolute",
-              bottom: 8,
-              right: 8,
-              zIndex: 1,
-            }}
-          >
-            <MdEdit />
-          </IconButton>
-        </Tooltip>
-      )}
-
       <Stack
         direction="row"
         spacing={1}
         justifyContent="space-between"
         alignItems="center"
       >
-        {isNil(onClick) && (
-          <Link overlay href={`cellars/${cellar.id}/items`}>
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{ minWidth: 0 }}
+        >
+          {isNil(onClick) && (
+            <Link overlay href={`cellars/${cellar.id}/items`}>
+              <Typography level="title-lg">{cellar.name}</Typography>
+            </Link>
+          )}
+          {isNotNil(onClick) && (
             <Typography level="title-lg">{cellar.name}</Typography>
-          </Link>
-        )}
-        {isNotNil(onClick) && (
-          <Typography level="title-lg">{cellar.name}</Typography>
-        )}
+          )}
+          {canEdit(userId, cellar) && (
+            <Tooltip title="Edit Cellar">
+              <IconButton
+                size="sm"
+                variant="soft"
+                onClick={() => onEditClick(cellar.id)}
+                sx={{
+                  position: "relative",
+                  zIndex: 1,
+                  flexShrink: 0,
+                }}
+              >
+                <MdEdit />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Stack>
         <AvatarGroup sx={{ flexShrink: 0 }}>
           <Tooltip title={cellar.createdBy.displayName}>
             <UserAvatar


### PR DESCRIPTION
## Summary
The cellar edit (pencil) button was absolutely positioned at the card's bottom-right corner, where it overlapped the item-count row (wine/beer/spirit/coffee counts). This moves it inline, immediately after the cellar name.

## Changes
- Removed the `position: absolute; bottom: 8; right: 8` edit button.
- Grouped the cellar name + edit button in a nested row `Stack` on the left; the avatar group stays on the right (outer `space-between` layout unchanged).
- Kept `position: relative; zIndex: 1` on the button so it remains clickable above the card's overlay `Link`, and added `flexShrink: 0`.

Header now reads: **Cellar Name** ✏️ … (avatars), with the counts row below and no overlap.

## Testing
- File compiles with no errors. Full live screenshot of the authenticated `/cellars` view was not captured because the automated browser sandboxes can't resolve the local Nhost auth hostname; the change is a contained presentational layout restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)