### PR TITLE
fix: Drop obsolete brace-expansion override; handle pnpm 11 build scripts

### DIFF
--- a/functions/_packages/shared/pnpm-lock.yaml
+++ b/functions/_packages/shared/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion: ^2.0.1
-
 importers:
 
   .:

--- a/functions/_packages/typescript-config/pnpm-lock.yaml
+++ b/functions/_packages/typescript-config/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion: ^2.0.1
-
 importers:
 
   .: {}

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion: ^2.0.1
-
 importers:
 
   .:

--- a/functions/pnpm-workspace.yaml
+++ b/functions/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
-overrides:
-  brace-expansion: "^2.0.1"
 allowBuilds:
   "@google/genai": false
   protobufjs: false

--- a/nhost/nhost.toml
+++ b/nhost/nhost.toml
@@ -23,6 +23,15 @@ value = 'us-central1-aiplatform.googleapis.com'
 name = 'CI'
 value = '1'
 
+# pnpm 11 fails frozen installs on unapproved dependency build scripts
+# (strictDepBuilds defaults to true). The functions build is standalone and
+# does not read pnpm-workspace.yaml's allowBuilds, so demote the error to a
+# warning here. These scripts (@google/genai, protobufjs) were never run on
+# prior pnpm 10 deploys, so this preserves behavior.
+[[global.environment]]
+name = 'PNPM_CONFIG_STRICT_DEP_BUILDS'
+value = 'false'
+
 [[global.environment]]
 name = 'AI_PROVIDER'
 value = '{{ secrets.AI_PROVIDER }}'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  brace-expansion: ^2.0.1
-
 importers:
 
   .:
@@ -2090,8 +2087,9 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   barcode-detector@3.2.0:
     resolution: {integrity: sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==}
@@ -2104,8 +2102,9 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5919,7 +5918,7 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   barcode-detector@3.2.0(@types/emscripten@1.41.5):
     dependencies:
@@ -5931,9 +5930,9 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
-  brace-expansion@2.0.2:
+  brace-expansion@5.0.6:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6435,7 +6434,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.6
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,8 +3,6 @@ packages:
   - "functions"
   - "functions/_packages/*"
 sharedWorkspaceLockfile: false
-overrides:
-  brace-expansion: "^2.0.1"
 minimumReleaseAgeExclude:
   - '@tanstack/react-virtual@3.14.2'
   - '@tanstack/virtual-core@3.17.0'


### PR DESCRIPTION
Follow-up to #574 and #577. The Nhost functions deploy still failed under pnpm 11 with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, even after moving the override into `functions/pnpm-workspace.yaml`.

## Root cause

Nhost builds the functions package as a **standalone project and does not use `pnpm-workspace.yaml`** (proven by faithful local reproduction: a functions copy *without* the workspace file fails with the identical error; *with* it, it passes). pnpm 11 also no longer reads `pnpm.overrides` from `package.json`. So there was **no file Nhost ships that could carry the override** into the functions build — the override recorded in the committed `functions/pnpm-lock.yaml` could never be matched.

## Fix: just remove the override

The `brace-expansion` override (`^2.0.1`) existed for [CVE-2025-5889](https://github.com/advisories/GHSA-v6h2-p8h4-qcjw) — a **Low-severity (CVSS 2.3)** ReDoS. It turned out to be obsolete and counterproductive:

- The override **pinned** `brace-expansion` to the older `2.0.2`. Removing it lets the tree resolve to **`5.0.6`** (current, fully patched). Verified **no vulnerable version** remains in any lockfile.
- `functions` has **no `brace-expansion` dependency at all** — the override was pure dead config there.

Regenerated all lockfiles (root + functions + `_packages`) override-free. The only dependency churn is `brace-expansion` 2.0.2→5.0.6 and its dep `balanced-match` 1.0.2→4.0.4 (both patched).

## Also: pnpm 11 build-scripts strictness

pnpm 11 turns unapproved dependency build scripts into a **hard error** on frozen installs (`strictDepBuilds` defaults to `true`); pnpm 10 only warned. The functions build can't read `allowBuilds` from `pnpm-workspace.yaml`, so this PR sets `PNPM_CONFIG_STRICT_DEP_BUILDS=false` in `nhost.toml` to demote it to a warning. `@google/genai` and `protobufjs` build scripts were never executed on prior (pnpm 10) deploys, so behavior is preserved. The `functions/pnpm-workspace.yaml` `allowBuilds` entries are kept for local standalone installs.

## Verification

Faithful standalone reproduction of the Nhost build — `functions/` copied **without** `pnpm-workspace.yaml`, override-free lockfile, `PNPM_CONFIG_STRICT_DEP_BUILDS=false`:

```
pnpm install --frozen-lockfile  →  EXIT 0
```

Without the env var, the same setup fails *only* on the build-scripts error (overrides mismatch is gone), confirming both halves of the fix.

## Note on `PNPM_CONFIG_STRICT_DEP_BUILDS`

This relies on `nhost.toml` `[[global.environment]]` being applied during the build/install step (it sits alongside the existing `CI=1`, which is a build-time signal). If Nhost only applies these at runtime, the next deploy will surface the build-scripts error and we'll pin the functions build to pnpm 10 instead — but the overrides fix here is independent and definitive either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)