### PR TITLE
fix: Pin functions build to pnpm 10 to clear pnpm 11 build-scripts gate

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -27,5 +27,6 @@
     "ollama": "0.6.3",
     "ramda": "0.32.0",
     "ts-pattern": "5.9.0"
-  }
+  },
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/functions/pnpm-workspace.yaml
+++ b/functions/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  "@google/genai": false
-  protobufjs: false

--- a/nhost/nhost.toml
+++ b/nhost/nhost.toml
@@ -23,15 +23,6 @@ value = 'us-central1-aiplatform.googleapis.com'
 name = 'CI'
 value = '1'
 
-# pnpm 11 fails frozen installs on unapproved dependency build scripts
-# (strictDepBuilds defaults to true). The functions build is standalone and
-# does not read pnpm-workspace.yaml's allowBuilds, so demote the error to a
-# warning here. These scripts (@google/genai, protobufjs) were never run on
-# prior pnpm 10 deploys, so this preserves behavior.
-[[global.environment]]
-name = 'PNPM_CONFIG_STRICT_DEP_BUILDS'
-value = 'false'
-
 [[global.environment]]
 name = 'AI_PROVIDER'
 value = '{{ secrets.AI_PROVIDER }}'


### PR DESCRIPTION
Follow-up to #574, #577, #583. The deploy now gets **past** the overrides mismatch (that fix from #583 worked — the install resolves all 129 packages and runs to completion). It fails only on the next pnpm 11 gate:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @google/genai@2.7.0, protobufjs@7.5.4
```

pnpm 11 turns unapproved dependency build scripts into a **hard error** on frozen installs (`strictDepBuilds` defaults to `true`); pnpm 10 only warned.

## Why the env var from #583 didn't work

The pnpm-11 controls for this (`allowBuilds`, `strictDepBuilds`) live only in `pnpm-workspace.yaml` or environment — and Nhost's standalone functions build reads **neither**. The `PNPM_CONFIG_STRICT_DEP_BUILDS=false` env var added in #583 had **no effect at build time** (the deploy proved Nhost doesn't apply `[[global.environment]]` during install). It's removed here.

## Fix: run the functions build on pnpm 10

Nhost runs corepack **inside `functions/`**, and corepack uses the **nearest** `packageManager`. So pinning `functions/package.json` to `pnpm@10.33.0` makes only the functions build use pnpm 10 (which warns, not errors, on ignored builds) while the root app stays on pnpm 11. `10.33.0` is the exact version functions deployed with before the pnpm 11 bump, and these build scripts were never executed on those deploys — so behavior is preserved.

Also deletes `functions/pnpm-workspace.yaml` (added in #577): it was pnpm-11 `allowBuilds` syntax that pnpm 10 ignores, and Nhost never read it.

## Verification

| Check | Result |
|---|---|
| Corepack version selected in `functions/` | **10.33.0** (nearest packageManager wins; verified with a nested-dir test) |
| Faithful Nhost-sim: functions copied **without** `pnpm-workspace.yaml`, `corepack pnpm install --frozen-lockfile` | **EXIT 0** (ignored builds → warning) |
| Root install under pnpm 11 with functions pinned to pnpm 10 | **EXIT 0**, no errors, no lockfile churn (Vercel/local dev unaffected) |

Net diff: `+1` packageManager line in `functions/package.json`, `-1` env var in `nhost.toml`, and the deletion of `functions/pnpm-workspace.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)