### PR TITLE
fix: Declare graphql and convert as functions dependencies

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -20,10 +20,12 @@
     "@urql/core": "6.0.1",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
+    "convert": "7.0.0",
     "form-data": "4.0.5",
     "fuzzball": "2.2.6",
     "google-auth-library": "^10.6.2",
     "gql.tada": "1.9.2",
+    "graphql": "16.8.1",
     "ollama": "0.6.3",
     "ramda": "0.32.0",
     "ts-pattern": "5.9.0"

--- a/functions/pnpm-lock.yaml
+++ b/functions/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       ajv-formats:
         specifier: 3.0.1
         version: 3.0.1(ajv@8.20.0)
+      convert:
+        specifier: 7.0.0
+        version: 7.0.0
       form-data:
         specifier: 4.0.5
         version: 4.0.5
@@ -50,6 +53,9 @@ importers:
       gql.tada:
         specifier: 1.9.2
         version: 1.9.2(graphql@16.8.1)(typescript@5.9.3)
+      graphql:
+        specifier: 16.8.1
+        version: 16.8.1
       ollama:
         specifier: 0.6.3
         version: 0.6.3
@@ -272,6 +278,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  convert@7.0.0:
+    resolution: {integrity: sha512-Sc8P9MeZBPtaAG/hiSYO28LvVjEDfP+iecvP1nvhJxvXcS3d9WQJIQma9XMPRwIWPifA2X8epIR9zbLxJPrT8w==}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -773,6 +782,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  convert@7.0.0: {}
 
   data-uri-to-buffer@4.0.1: {}
 


### PR DESCRIPTION
Follow-up to #584. With the install finally green under pnpm 10, the functions deploy reached the **esbuild build** step, which failed:

```
✘ [ERROR] Could not resolve "graphql"   (_utils/urql-client.ts:12)
```

## Cause

The functions package imports two runtime deps it **never declared** — they existed only transitively / at the repo root, so pnpm's isolated `node_modules` didn't symlink them into `functions/node_modules`, and esbuild couldn't resolve the bare imports:

| Package | Import | Used by |
|---|---|---|
| `graphql` | `import { print } from "graphql"` | `_utils/urql-client.ts` |
| `convert` | `import { convert } from "convert"` | `_utils/shared-enums.ts` → processRecipePhoto, getItemDefaults, recipe-database, … |

`express` and `json-schema` are also imported but only as `import type`, which esbuild erases — no runtime dep needed (and Nhost injects `express` via its serverless runtime).

This is a latent missing-dependency bug, unrelated to the pnpm/lockfile work — it only surfaced now that the build step runs for the first time in a while.

## Fix

Declare both directly in `functions/package.json`:
- `graphql` at **16.8.1** — the version already resolved in the functions tree, so no peer-dependency churn.
- `convert` at **7.0.0** — matching the root declaration.

## Verification

- pnpm 10 `--frozen-lockfile` install symlinks both `graphql` and `convert` at the top level of `functions/node_modules`.
- **esbuild bundles all 29 function entry points with zero unresolved imports** (previously `discoverPlaceMenu` failed on `graphql`).

> Note: the deploy log also shows a non-fatal warning — `Cannot find base config file "@cellar-assistant/typescript-config/nextjs.json"` from the repo-root `tsconfig.json`. esbuild treats it as a warning and continues; it did not block the build. Left as-is to keep this PR scoped to the build failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)