### PR TITLE
feat: align tea and sake item detail pages with other item types

### DIFF
--- a/src/app/(authenticated)/cellars/[cellarId]/getCellarItemData.ts
+++ b/src/app/(authenticated)/cellars/[cellarId]/getCellarItemData.ts
@@ -25,6 +25,14 @@ const cellarItemQuery = graphql(`
         id
         name
       }
+      sake {
+        id
+        name
+      }
+      tea {
+        id
+        name
+      }
     }
   }
 `);
@@ -44,7 +52,9 @@ export async function getCellarItemData(itemId: string) {
       item.beer?.name ||
       item.wine?.name ||
       item.spirit?.name ||
-      item.coffee?.name;
+      item.coffee?.name ||
+      item.sake?.name ||
+      item.tea?.name;
 
     return {
       ...item,

--- a/src/app/(authenticated)/cellars/[cellarId]/sakes/[itemId]/page.tsx
+++ b/src/app/(authenticated)/cellars/[cellarId]/sakes/[itemId]/page.tsx
@@ -1,28 +1,41 @@
+import { Typography } from "@mui/joy";
 import { CellarSakeDetails } from "@/components/sake/CellarSakeDetails";
 import { GetCellarSakeDetailsQuery } from "@/components/sake/fragments";
 import { serverQuery } from "@/lib/urql/server";
 import { getServerUserId } from "@/utilities/auth-server";
+import { getCellarItemData } from "../../getCellarItemData";
 
 export default async function CellarSakeDetailsPage({
   params,
 }: {
   params: Promise<{ itemId: string; cellarId: string }>;
 }) {
-  const { itemId } = await params;
+  const { itemId, cellarId } = await params;
   const userId = await getServerUserId();
 
-  // Fetch data server-side for immediate rendering
-  const data = await serverQuery(GetCellarSakeDetailsQuery, { itemId, userId });
+  // Fetch cellar item data server-side for breadcrumbs
+  const cellarItemData = await getCellarItemData(itemId);
 
-  if (!data.cellar_items_by_pk) {
-    return <div>Cellar sake item not found</div>;
+  if (!cellarItemData) {
+    return <Typography>Item not found</Typography>;
   }
 
-  if (!data.user) {
-    return <div>User not found</div>;
+  // Fetch detailed data server-side for immediate rendering
+  const data = await serverQuery(GetCellarSakeDetailsQuery, { itemId, userId });
+
+  if (!data.cellar_items_by_pk || !data.user) {
+    return <Typography>Item not found</Typography>;
   }
 
   return (
-    <CellarSakeDetails cellarItem={data.cellar_items_by_pk} user={data.user} />
+    <CellarSakeDetails
+      cellarItem={data.cellar_items_by_pk}
+      user={data.user}
+      itemId={itemId}
+      cellarId={cellarId}
+      userId={userId}
+      cellarName={cellarItemData.cellar.name}
+      itemName={cellarItemData.itemName}
+    />
   );
 }

--- a/src/app/(authenticated)/cellars/[cellarId]/teas/[itemId]/page.tsx
+++ b/src/app/(authenticated)/cellars/[cellarId]/teas/[itemId]/page.tsx
@@ -1,28 +1,41 @@
+import { Typography } from "@mui/joy";
 import { CellarTeaDetails } from "@/components/tea/CellarTeaDetails";
 import { GetCellarTeaDetailsQuery } from "@/components/tea/fragments";
 import { serverQuery } from "@/lib/urql/server";
 import { getServerUserId } from "@/utilities/auth-server";
+import { getCellarItemData } from "../../getCellarItemData";
 
 export default async function CellarTeaDetailsPage({
   params,
 }: {
   params: Promise<{ itemId: string; cellarId: string }>;
 }) {
-  const { itemId } = await params;
+  const { itemId, cellarId } = await params;
   const userId = await getServerUserId();
 
-  // Fetch data server-side for immediate rendering
-  const data = await serverQuery(GetCellarTeaDetailsQuery, { itemId, userId });
+  // Fetch cellar item data server-side for breadcrumbs
+  const cellarItemData = await getCellarItemData(itemId);
 
-  if (!data.cellar_items_by_pk) {
-    return <div>Cellar tea item not found</div>;
+  if (!cellarItemData) {
+    return <Typography>Item not found</Typography>;
   }
 
-  if (!data.user) {
-    return <div>User not found</div>;
+  // Fetch detailed data server-side for immediate rendering
+  const data = await serverQuery(GetCellarTeaDetailsQuery, { itemId, userId });
+
+  if (!data.cellar_items_by_pk || !data.user) {
+    return <Typography>Item not found</Typography>;
   }
 
   return (
-    <CellarTeaDetails cellarItem={data.cellar_items_by_pk} user={data.user} />
+    <CellarTeaDetails
+      cellarItem={data.cellar_items_by_pk}
+      user={data.user}
+      itemId={itemId}
+      cellarId={cellarId}
+      userId={userId}
+      cellarName={cellarItemData.cellar.name}
+      itemName={cellarItemData.itemName}
+    />
   );
 }

--- a/src/components/item/ItemImageWithCaptureClient.tsx
+++ b/src/components/item/ItemImageWithCaptureClient.tsx
@@ -15,7 +15,7 @@ interface ItemImageWithCaptureClientProps {
   placeholder?: string | null;
   fallback: StaticImageData;
   itemId: string;
-  itemType: "BEER" | "WINE" | "SPIRIT" | "COFFEE";
+  itemType: "BEER" | "WINE" | "SPIRIT" | "COFFEE" | "SAKE" | "TEA";
   cellarItemId: string;
 }
 

--- a/src/components/review/AddReview.tsx
+++ b/src/components/review/AddReview.tsx
@@ -26,37 +26,65 @@ interface AddBeerReviewProps {
   wineId?: never;
   spiritId?: never;
   coffeeId?: never;
+  sakeId?: never;
+  teaId?: never;
 }
 interface AddWineReviewProps {
   wineId: string;
   beerId?: never;
   spiritId?: never;
   coffeeId?: never;
+  sakeId?: never;
+  teaId?: never;
 }
 interface AddSpiritReviewProps {
   spiritId: string;
   beerId?: never;
   wineId?: never;
   coffeeId?: never;
+  sakeId?: never;
+  teaId?: never;
 }
 interface AddCoffeeReviewProps {
   coffeeId: string;
   beerId?: never;
   wineId?: never;
   spiritId?: never;
+  sakeId?: never;
+  teaId?: never;
+}
+interface AddSakeReviewProps {
+  sakeId: string;
+  beerId?: never;
+  wineId?: never;
+  spiritId?: never;
+  coffeeId?: never;
+  teaId?: never;
+}
+interface AddTeaReviewProps {
+  teaId: string;
+  beerId?: never;
+  wineId?: never;
+  spiritId?: never;
+  coffeeId?: never;
+  sakeId?: never;
 }
 
 export type AddReviewProps =
   | AddBeerReviewProps
   | AddWineReviewProps
   | AddCoffeeReviewProps
-  | AddSpiritReviewProps;
+  | AddSpiritReviewProps
+  | AddSakeReviewProps
+  | AddTeaReviewProps;
 
 export const AddReview = ({
   beerId,
   spiritId,
   wineId,
   coffeeId,
+  sakeId,
+  teaId,
 }: AddReviewProps) => {
   const [isPending, startTransition] = useTransition();
   const [open, setOpen] = useState(false);
@@ -77,6 +105,8 @@ export const AddReview = ({
           wineId,
           spiritId,
           coffeeId,
+          sakeId,
+          teaId,
           score,
           text,
         });

--- a/src/components/sake/CellarSakeDetails.tsx
+++ b/src/components/sake/CellarSakeDetails.tsx
@@ -1,32 +1,73 @@
 import { type FragmentOf, readFragment } from "@cellar-assistant/shared";
-import { Box, Card, CardContent, Chip, Typography } from "@mui/joy";
-import { ItemBrands } from "../item/ItemBrands";
-import { ItemCard } from "../item/ItemCard";
-import { ItemRecipes } from "../item/ItemRecipes";
+import {
+  formatCountry,
+  formatEnum,
+  getIsCellarOwner,
+} from "@cellar-assistant/shared/utility";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { notFound } from "next/navigation";
+import { isNil, isNotNil, nth } from "ramda";
+import { CellarItemHeader } from "@/components/item/CellarItemHeader";
+import { ItemBrands } from "@/components/item/ItemBrands";
+import { ItemCheckIns } from "@/components/item/ItemCheckIns";
+import ItemDetails from "@/components/item/ItemDetails";
+import { ItemImageWithCaptureClient } from "@/components/item/ItemImageWithCaptureClient";
+import { ItemRecipes } from "@/components/item/ItemRecipes";
+import { ItemRemainingSlider } from "@/components/item/ItemRemainingSlider";
+import { ItemReviews } from "@/components/item/ItemReviews";
+import { ItemShare } from "@/components/item/ItemShare";
+import { AddReview } from "@/components/review/AddReview";
+import sake1 from "@/images/sake1.png";
+import { parseDate } from "@/utilities";
 import {
   CellarSakeDetailsFragment,
-  type UserWithFriendsFragment,
+  UserWithFriendsFragment,
 } from "./fragments";
 
 interface CellarSakeDetailsProps {
   cellarItem: FragmentOf<typeof CellarSakeDetailsFragment>;
   user: FragmentOf<typeof UserWithFriendsFragment>;
+  itemId: string;
+  cellarId: string;
+  userId: string;
+  cellarName?: string;
+  itemName?: string;
 }
 
 export function CellarSakeDetails({
   cellarItem,
-  user: _user,
+  user,
+  itemId,
+  cellarId,
+  userId,
+  cellarName,
+  itemName,
 }: CellarSakeDetailsProps) {
+  if (isNil(cellarItem) || isNil(user)) {
+    notFound();
+  }
+
   const item = readFragment(CellarSakeDetailsFragment, cellarItem);
+  const userData = readFragment(UserWithFriendsFragment, user);
   const sake = item.sake;
 
   if (!sake) {
-    return <div>Sake not found</div>;
+    notFound();
   }
 
+  const isOwner = getIsCellarOwner(userId, item.cellar);
+
   const characteristics = [
-    { label: "Category", value: sake.category },
-    { label: "Type", value: sake.type },
+    { label: "Category", value: formatEnum(sake.category) },
+    { label: "Type", value: formatEnum(sake.type) },
     {
       label: "Polish Grade",
       value: sake.polish_grade ? `${sake.polish_grade}%` : undefined,
@@ -40,82 +81,102 @@ export function CellarSakeDetails({
     { label: "SMV", value: sake.sake_meter_value },
     { label: "Acidity", value: sake.acidity },
     { label: "Rice Variety", value: sake.rice_variety },
-    { label: "Serving Temp", value: sake.serving_temperature },
+    { label: "Yeast Strain", value: sake.yeast_strain },
+    { label: "Serving Temp", value: formatEnum(sake.serving_temperature) },
     { label: "Vintage", value: sake.vintage },
-    { label: "Region", value: sake.region },
-  ].filter((item) => item.value !== null && item.value !== undefined);
+  ].filter((char) => isNotNil(char.value) && char.value !== "");
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {/* Main item card */}
-      <ItemCard
-        item={{
-          id: sake.id,
-          itemId: sake.id,
-          name: sake.name,
-        }}
-        type={"SAKE"}
+    <Stack spacing={2}>
+      <CellarItemHeader
+        itemType={"SAKE"}
+        itemId={itemId}
+        itemName={itemName || sake.name}
+        cellarId={cellarId}
+        cellarName={cellarName || item.cellar?.name}
+        isOwner={isOwner}
+        userId={userId}
       />
-
-      {/* Sake characteristics */}
-      <Card>
-        <CardContent>
-          <Typography level="h3" sx={{ mb: 2 }}>
-            Sake Characteristics
-          </Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {characteristics.map((char) => (
-              <Chip key={char.label} variant="outlined">
-                {char.label}: {char.value}
-              </Chip>
-            ))}
-          </Box>
-        </CardContent>
-      </Card>
-
-      {/* Brands */}
-      {sake.brands && sake.brands.length > 0 && (
-        <ItemBrands brands={sake.brands} />
-      )}
-
-      {/* Recipes */}
-      {sake.recipe_ingredients && sake.recipe_ingredients.length > 0 && (
-        <ItemRecipes
-          recipeIngredients={sake.recipe_ingredients}
-          itemName={sake.name}
-        />
-      )}
-
-      {/* Description */}
-      {sake.description && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Description
-            </Typography>
-            <Typography>{sake.description}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Check-ins */}
-      {item.check_ins && item.check_ins.length > 0 && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Recent Check-ins
-            </Typography>
-            {item.check_ins.slice(0, 5).map((checkin) => (
-              <Box key={checkin.id} sx={{ mb: 1 }}>
-                <Typography level="body-sm">
-                  {checkin.user.displayName} -{" "}
-                  {new Date(checkin.createdAt).toLocaleDateString()}
-                </Typography>
-              </Box>
-            ))}
-          </CardContent>
-        </Card>
-      )}
-    </Box>
+      <Grid container spacing={2}>
+        <Grid xs={12} sm={4}>
+          <ItemImageWithCaptureClient
+            fileId={item.display_image?.file_id}
+            placeholder={item.display_image?.placeholder}
+            fallback={sake1}
+            itemId={sake.id}
+            itemType="SAKE"
+            cellarItemId={itemId}
+          />
+        </Grid>
+        <Grid container xs={12} sm={8}>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <ItemDetails
+                itemId={sake.id}
+                type={"SAKE"}
+                favoriteId={nth(0, sake.item_favorites || [])?.id}
+                title={sake.name || ""}
+                subTitlePhrases={[
+                  formatEnum(sake.category),
+                  formatEnum(sake.type),
+                  formatCountry(sake.country),
+                  sake.region,
+                ]}
+                description={sake.description}
+              />
+              {characteristics.length > 0 && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Sake Characteristics
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                      {characteristics.map((char) => (
+                        <Chip key={char.label} variant="outlined">
+                          {char.label}: {char.value}
+                        </Chip>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              )}
+              {isNotNil(item.open_at) && (
+                <ItemCheckIns
+                  checkIns={item.check_ins}
+                  itemId={item.id}
+                  friends={userData?.friends?.map((x) => x.friend) || []}
+                  user={userData}
+                />
+              )}
+              <ItemRemainingSlider
+                itemId={itemId}
+                cellarId={cellarId}
+                isCellarOwner={isOwner}
+                percentageRemaining={item.percentage_remaining}
+                opened={parseDate(item.open_at)}
+                emptied={parseDate(item.empty_at)}
+              />
+              <ItemShare itemId={sake.id} itemType={"SAKE"} />
+              {sake.brands && sake.brands.length > 0 && (
+                <ItemBrands brands={sake.brands} title="Breweries" />
+              )}
+              {sake.recipe_ingredients &&
+                sake.recipe_ingredients.length > 0 && (
+                  <ItemRecipes
+                    recipeIngredients={sake.recipe_ingredients}
+                    itemName={sake.name}
+                  />
+                )}
+            </Stack>
+          </Grid>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <AddReview sakeId={sake.id} />
+              <ItemReviews reviews={sake.reviews || []} />
+            </Stack>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Stack>
   );
 }

--- a/src/components/tea/CellarTeaDetails.tsx
+++ b/src/components/tea/CellarTeaDetails.tsx
@@ -1,140 +1,194 @@
 import { type FragmentOf, readFragment } from "@cellar-assistant/shared";
-import { Box, Card, CardContent, Chip, Typography } from "@mui/joy";
-import { ItemBrands } from "../item/ItemBrands";
-import { ItemCard } from "../item/ItemCard";
-import { ItemRecipes } from "../item/ItemRecipes";
+import {
+  formatCountry,
+  formatEnum,
+  getIsCellarOwner,
+} from "@cellar-assistant/shared/utility";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { notFound } from "next/navigation";
+import { isNil, isNotNil, nth } from "ramda";
+import { CellarItemHeader } from "@/components/item/CellarItemHeader";
+import { ItemBrands } from "@/components/item/ItemBrands";
+import { ItemCheckIns } from "@/components/item/ItemCheckIns";
+import ItemDetails from "@/components/item/ItemDetails";
+import { ItemImageWithCaptureClient } from "@/components/item/ItemImageWithCaptureClient";
+import { ItemRecipes } from "@/components/item/ItemRecipes";
+import { ItemRemainingSlider } from "@/components/item/ItemRemainingSlider";
+import { ItemReviews } from "@/components/item/ItemReviews";
+import { ItemShare } from "@/components/item/ItemShare";
+import { AddReview } from "@/components/review/AddReview";
+import tea1 from "@/images/tea1.png";
+import { parseDate } from "@/utilities";
 import {
   CellarTeaDetailsFragment,
-  type UserWithFriendsFragment,
+  UserWithFriendsFragment,
 } from "./fragments";
 
 interface CellarTeaDetailsProps {
   cellarItem: FragmentOf<typeof CellarTeaDetailsFragment>;
   user: FragmentOf<typeof UserWithFriendsFragment>;
+  itemId: string;
+  cellarId: string;
+  userId: string;
+  cellarName?: string;
+  itemName?: string;
 }
 
 export function CellarTeaDetails({
   cellarItem,
-  user: _user,
+  user,
+  itemId,
+  cellarId,
+  userId,
+  cellarName,
+  itemName,
 }: CellarTeaDetailsProps) {
+  if (isNil(cellarItem) || isNil(user)) {
+    notFound();
+  }
+
   const item = readFragment(CellarTeaDetailsFragment, cellarItem);
+  const userData = readFragment(UserWithFriendsFragment, user);
   const tea = item.tea;
 
   if (!tea) {
-    return <div>Tea not found</div>;
+    notFound();
   }
 
+  const isOwner = getIsCellarOwner(userId, item.cellar);
+
   const characteristics = [
-    { label: "Category", value: tea.category },
-    { label: "Form", value: tea.form },
-    { label: "Caffeine", value: tea.caffeine_level },
-    { label: "Oxidation", value: tea.oxidation_level },
-    { label: "Processing", value: tea.processing },
+    { label: "Category", value: formatEnum(tea.category) },
+    { label: "Form", value: formatEnum(tea.form) },
+    { label: "Caffeine", value: formatEnum(tea.caffeine_level) },
+    { label: "Oxidation", value: formatEnum(tea.oxidation_level) },
+    { label: "Processing", value: formatEnum(tea.processing) },
     { label: "Cultivar", value: tea.cultivar },
     { label: "Harvest Year", value: tea.harvest_year },
     { label: "Steep Temp", value: tea.steeping_temperature },
     { label: "Steep Time", value: tea.steeping_time },
-    { label: "Country", value: tea.country },
-    { label: "Region", value: tea.region },
     { label: "Organic", value: tea.is_organic ? "Yes" : undefined },
     { label: "Fair Trade", value: tea.is_fair_trade ? "Yes" : undefined },
-  ].filter((item) => item.value !== null && item.value !== undefined);
+  ].filter((char) => isNotNil(char.value) && char.value !== "");
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {/* Main item card */}
-      <ItemCard
-        item={{
-          id: tea.id,
-          itemId: tea.id,
-          name: tea.name,
-        }}
-        type={"TEA"}
+    <Stack spacing={2}>
+      <CellarItemHeader
+        itemType={"TEA"}
+        itemId={itemId}
+        itemName={itemName || tea.name}
+        cellarId={cellarId}
+        cellarName={cellarName || item.cellar?.name}
+        isOwner={isOwner}
+        userId={userId}
       />
-
-      {/* Tea characteristics */}
-      <Card>
-        <CardContent>
-          <Typography level="h3" sx={{ mb: 2 }}>
-            Tea Characteristics
-          </Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {characteristics.map((char) => (
-              <Chip key={char.label} variant="outlined">
-                {char.label}: {char.value}
-              </Chip>
-            ))}
-          </Box>
-        </CardContent>
-      </Card>
-
-      {/* Brands */}
-      {tea.brands && tea.brands.length > 0 && (
-        <ItemBrands brands={tea.brands} />
-      )}
-
-      {/* Recipes */}
-      {tea.recipe_ingredients && tea.recipe_ingredients.length > 0 && (
-        <ItemRecipes
-          recipeIngredients={tea.recipe_ingredients}
-          itemName={tea.name}
-        />
-      )}
-
-      {/* Ingredients */}
-      {tea.ingredients && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Ingredients
-            </Typography>
-            <Typography>{tea.ingredients}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Flavor profile */}
-      {tea.flavor_profile && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Flavor Profile
-            </Typography>
-            <Typography>{tea.flavor_profile}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Description */}
-      {tea.description && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Description
-            </Typography>
-            <Typography>{tea.description}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Check-ins */}
-      {item.check_ins && item.check_ins.length > 0 && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Recent Check-ins
-            </Typography>
-            {item.check_ins.slice(0, 5).map((checkin) => (
-              <Box key={checkin.id} sx={{ mb: 1 }}>
-                <Typography level="body-sm">
-                  {checkin.user.displayName} -{" "}
-                  {new Date(checkin.createdAt).toLocaleDateString()}
-                </Typography>
-              </Box>
-            ))}
-          </CardContent>
-        </Card>
-      )}
-    </Box>
+      <Grid container spacing={2}>
+        <Grid xs={12} sm={4}>
+          <ItemImageWithCaptureClient
+            fileId={item.display_image?.file_id}
+            placeholder={item.display_image?.placeholder}
+            fallback={tea1}
+            itemId={tea.id}
+            itemType="TEA"
+            cellarItemId={itemId}
+          />
+        </Grid>
+        <Grid container xs={12} sm={8}>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <ItemDetails
+                itemId={tea.id}
+                type={"TEA"}
+                favoriteId={nth(0, tea.item_favorites || [])?.id}
+                title={tea.name || ""}
+                subTitlePhrases={[
+                  formatEnum(tea.category),
+                  formatEnum(tea.form),
+                  formatCountry(tea.country),
+                  tea.region,
+                ]}
+                description={tea.description}
+              />
+              {characteristics.length > 0 && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Tea Characteristics
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                      {characteristics.map((char) => (
+                        <Chip key={char.label} variant="outlined">
+                          {char.label}: {char.value}
+                        </Chip>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              )}
+              {tea.flavor_profile && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Flavor Profile
+                    </Typography>
+                    <Typography>{tea.flavor_profile}</Typography>
+                  </CardContent>
+                </Card>
+              )}
+              {tea.ingredients && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Ingredients
+                    </Typography>
+                    <Typography>{tea.ingredients}</Typography>
+                  </CardContent>
+                </Card>
+              )}
+              {isNotNil(item.open_at) && (
+                <ItemCheckIns
+                  checkIns={item.check_ins}
+                  itemId={item.id}
+                  friends={userData?.friends?.map((x) => x.friend) || []}
+                  user={userData}
+                />
+              )}
+              <ItemRemainingSlider
+                itemId={itemId}
+                cellarId={cellarId}
+                isCellarOwner={isOwner}
+                percentageRemaining={item.percentage_remaining}
+                opened={parseDate(item.open_at)}
+                emptied={parseDate(item.empty_at)}
+              />
+              <ItemShare itemId={tea.id} itemType={"TEA"} />
+              {tea.brands && tea.brands.length > 0 && (
+                <ItemBrands brands={tea.brands} title="Brands" />
+              )}
+              {tea.recipe_ingredients && tea.recipe_ingredients.length > 0 && (
+                <ItemRecipes
+                  recipeIngredients={tea.recipe_ingredients}
+                  itemName={tea.name}
+                />
+              )}
+            </Stack>
+          </Grid>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <AddReview teaId={tea.id} />
+              <ItemReviews reviews={tea.reviews || []} />
+            </Stack>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Stack>
   );
 }


### PR DESCRIPTION
## What

Brings the **tea** and **sake** detail pages up to parity with wine/beer/spirit/coffee, on **both** the cellar-scoped (`/cellars/[cellarId]/{teas,sakes}/[itemId]`) and standalone (`/teas/[itemId]`, `/sakes/[itemId]`) routes. All four were simplified placeholders using a single-column `ItemCard` layout.

## Why

A user noticed the tea detail page (and, on inspection, sake) looked very different from the other item types:
- No way to add/see reviews
- The photo taken during onboarding didn't show up
- Responsiveness was broken (everything stacked in one column)
- Overall layout diverged from the rest of the app

The backend already fully supported both types (reviews, favorites, `item_type` image upload, tier-list entity types) — every gap was front-end only.

## Changes

**Cellar-scoped detail components** — `CellarTeaDetails` / `CellarSakeDetails` rewritten to mirror `CellarWineDetails`:
- `CellarItemHeader` (breadcrumbs + delete action)
- Responsive MUI `Grid` two-column layout (image left; details + reviews right)
- `ItemImageWithCaptureClient` — renders the onboarding photo (`display_image`) with the type's placeholder fallback
- `ItemDetails`, type-specific characteristics chip card, `ItemCheckIns`, `ItemRemainingSlider`, `ItemShare`, `ItemBrands`, `ItemRecipes`, `AddReview` + `ItemReviews`

**Standalone detail components** — `TeaDetails` / `SakeDetails` rewritten to mirror `WineDetails`:
- `ItemHeaderServer` (add-to-cellar actions)
- Responsive `Grid` two-column layout, `ItemImage` + `ItemShare`
- `ItemDetails`, characteristics chip card, `ItemCellars`, `ItemTierLists`, `AddReview` + `ItemReviews` + `ItemBrands` + `ItemRecipes` + `CompactRecipeRecommendations`

**Supporting changes:**
- `getCellarItemData` — added `tea`/`sake` to the breadcrumb query and name fallback
- cellar tea/sake page routes — fetch breadcrumb data and pass `itemId`/`cellarId`/`userId`/`cellarName`/`itemName`
- standalone tea/sake page routes — pass `cellars`/`itemId` (queries already returned `cellars`)
- `AddReview` — added `teaId`/`sakeId` to the props union and passed them to the (already-supporting) server action
- `ItemImageWithCaptureClient` — added `"TEA"` and `"SAKE"` to the `itemType` union

(`ItemTierLists` already supported `tea`/`sake` entity types — no change needed.)

## Verification

- `pnpm typecheck`: **no new type errors.** The only errors reported are the pre-existing fresh-worktree `@/images/*.png` TS2307 baseline (present identically across all detail components, caused by the gitignored generated `next-env.d.ts`).
- Biome-formatted.
- No live browser pass — no dev server was reachable during the change. Worth a manual look at a tea and a sake item on both the cellar and standalone pages to confirm the header, image, review box, and responsive layout render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)