### PR TITLE
feat: align standalone tea and sake item detail pages with other types

### DIFF
--- a/src/app/(authenticated)/sakes/[itemId]/page.tsx
+++ b/src/app/(authenticated)/sakes/[itemId]/page.tsx
@@ -18,5 +18,11 @@ export default async function SakeDetailsPage({
     return <div>Sake not found</div>;
   }
 
-  return <SakeDetails sakeData={data.sakes_by_pk} />;
+  return (
+    <SakeDetails
+      sakeData={data.sakes_by_pk}
+      cellars={data.cellars}
+      itemId={itemId}
+    />
+  );
 }

--- a/src/app/(authenticated)/teas/[itemId]/page.tsx
+++ b/src/app/(authenticated)/teas/[itemId]/page.tsx
@@ -18,5 +18,11 @@ export default async function TeaDetailsPage({
     return <div>Tea not found</div>;
   }
 
-  return <TeaDetails teaData={data.teas_by_pk} />;
+  return (
+    <TeaDetails
+      teaData={data.teas_by_pk}
+      cellars={data.cellars}
+      itemId={itemId}
+    />
+  );
 }

--- a/src/components/sake/SakeDetails.tsx
+++ b/src/components/sake/SakeDetails.tsx
@@ -1,91 +1,167 @@
-import type { FragmentOf } from "@cellar-assistant/shared";
-import { readFragment } from "@cellar-assistant/shared";
-import { Box, Card, CardContent, Chip, Typography } from "@mui/joy";
-import { ItemBrands } from "../item/ItemBrands";
-import { ItemCard } from "../item/ItemCard";
-import { ItemRecipes } from "../item/ItemRecipes";
-import { SakeDetailsFragment } from "./fragments";
+import { type FragmentOf, readFragment } from "@cellar-assistant/shared";
+import { formatCountry, formatEnum } from "@cellar-assistant/shared/utility";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { notFound } from "next/navigation";
+import { isNil, isNotNil, nth } from "ramda";
+import { ItemBrands } from "@/components/item/ItemBrands";
+import { ItemCellars } from "@/components/item/ItemCellars";
+import ItemDetails from "@/components/item/ItemDetails";
+import { ItemHeaderServer } from "@/components/item/ItemHeaderServer";
+import { ItemImage } from "@/components/item/ItemImage";
+import { ItemRecipes } from "@/components/item/ItemRecipes";
+import { ItemReviews } from "@/components/item/ItemReviews";
+import { ItemShare } from "@/components/item/ItemShare";
+import { ItemTierLists } from "@/components/item/ItemTierLists";
+import { CompactRecipeRecommendations } from "@/components/recipe/RecipeRecommendations";
+import { AddReview } from "@/components/review/AddReview";
+import sake1 from "@/images/sake1.png";
+import {
+  SakeCellarsFragment,
+  SakeCoreFragment,
+  type SakeDetailsFragment,
+  SakeImagesFragment,
+  SakeRelationshipsFragment,
+  SakeReviewsFragment,
+  SakeUserDataFragment,
+} from "./fragments";
 
 interface SakeDetailsProps {
   sakeData: FragmentOf<typeof SakeDetailsFragment>;
+  cellars: Array<{ id: string; name: string }>;
+  itemId: string;
+  userId?: string;
 }
 
-export function SakeDetails({ sakeData }: SakeDetailsProps) {
-  const sake = readFragment(SakeDetailsFragment, sakeData);
+export function SakeDetails({
+  sakeData,
+  cellars,
+  itemId,
+  userId,
+}: SakeDetailsProps) {
+  if (isNil(sakeData)) {
+    notFound();
+  }
+
+  const coreData = readFragment(SakeCoreFragment, sakeData);
+  const imageData = readFragment(SakeImagesFragment, sakeData);
+  const userData = readFragment(SakeUserDataFragment, sakeData);
+  const reviews = readFragment(SakeReviewsFragment, sakeData);
+  const cellarItems = readFragment(SakeCellarsFragment, sakeData);
+  const relationships = readFragment(SakeRelationshipsFragment, sakeData);
+
+  const displayImage = nth(0, imageData.item_images ?? []);
 
   const characteristics = [
-    { label: "Category", value: sake.category },
-    { label: "Type", value: sake.type },
+    { label: "Category", value: formatEnum(coreData.category) },
+    { label: "Type", value: formatEnum(coreData.type) },
     {
       label: "Polish Grade",
-      value: sake.polish_grade ? `${sake.polish_grade}%` : undefined,
+      value: coreData.polish_grade ? `${coreData.polish_grade}%` : undefined,
     },
     {
       label: "ABV",
-      value: sake.alcohol_content_percentage
-        ? `${sake.alcohol_content_percentage}%`
+      value: coreData.alcohol_content_percentage
+        ? `${coreData.alcohol_content_percentage}%`
         : undefined,
     },
-    { label: "SMV", value: sake.sake_meter_value },
-    { label: "Acidity", value: sake.acidity },
-    { label: "Rice Variety", value: sake.rice_variety },
-    { label: "Serving Temp", value: sake.serving_temperature },
-    { label: "Vintage", value: sake.vintage },
-    { label: "Region", value: sake.region },
-  ].filter((item) => item.value !== null && item.value !== undefined);
+    { label: "SMV", value: coreData.sake_meter_value },
+    { label: "Acidity", value: coreData.acidity },
+    { label: "Rice Variety", value: coreData.rice_variety },
+    { label: "Yeast Strain", value: coreData.yeast_strain },
+    { label: "Serving Temp", value: formatEnum(coreData.serving_temperature) },
+    { label: "Vintage", value: coreData.vintage },
+  ].filter((char) => isNotNil(char.value) && char.value !== "");
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {/* Main item card */}
-      <ItemCard
-        item={{
-          id: sake.id,
-          itemId: sake.id,
-          name: sake.name,
-        }}
-        type={"SAKE"}
+    <Stack spacing={2}>
+      <ItemHeaderServer
+        itemId={itemId}
+        itemName={coreData.name}
+        itemType={"SAKE"}
+        cellars={cellars}
       />
+      <Grid container spacing={2}>
+        <Grid xs={12} sm={4}>
+          <Stack spacing={1}>
+            <ItemImage
+              fileId={displayImage?.file_id}
+              placeholder={displayImage?.placeholder}
+              fallback={sake1}
+            />
+            <ItemShare itemId={coreData.id} itemType={"SAKE"} />
+          </Stack>
+        </Grid>
+        <Grid container xs={12} sm={8}>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <ItemDetails
+                itemId={coreData.id}
+                type={"SAKE"}
+                favoriteId={nth(0, userData.item_favorites)?.id}
+                title={coreData.name}
+                subTitlePhrases={[
+                  formatEnum(coreData.category),
+                  formatEnum(coreData.type),
+                  formatCountry(coreData.country),
+                  coreData.region,
+                ]}
+                description={coreData.description}
+              />
+              {characteristics.length > 0 && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Sake Characteristics
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                      {characteristics.map((char) => (
+                        <Chip key={char.label} variant="outlined">
+                          {char.label}: {char.value}
+                        </Chip>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              )}
+              <ItemCellars
+                cellars={cellarItems.cellar_items.map((x) => ({
+                  ...x.cellar,
+                  co_owners: x.cellar.co_owners.map((y) => y.user),
+                }))}
+              />
+              <ItemTierLists entityId={coreData.id} entityType="sake" />
+            </Stack>
+          </Grid>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <AddReview sakeId={coreData.id} />
+              <ItemReviews reviews={reviews.reviews} />
 
-      {/* Sake characteristics */}
-      <Card>
-        <CardContent>
-          <Typography level="h3" sx={{ mb: 2 }}>
-            Sake Characteristics
-          </Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {characteristics.map((char) => (
-              <Chip key={char.label} variant="outlined">
-                {char.label}: {char.value}
-              </Chip>
-            ))}
-          </Box>
-        </CardContent>
-      </Card>
+              <ItemBrands brands={relationships.brands} title="Breweries" />
 
-      {/* Brands */}
-      {sake.brands && sake.brands.length > 0 && (
-        <ItemBrands brands={sake.brands} />
-      )}
+              <ItemRecipes
+                recipeIngredients={relationships.recipe_ingredients}
+                title="Used in Recipes"
+                itemName={coreData.name}
+              />
 
-      {/* Recipes */}
-      {sake.recipe_ingredients && sake.recipe_ingredients.length > 0 && (
-        <ItemRecipes
-          recipeIngredients={sake.recipe_ingredients}
-          itemName={sake.name}
-        />
-      )}
-
-      {/* Description */}
-      {sake.description && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Description
-            </Typography>
-            <Typography>{sake.description}</Typography>
-          </CardContent>
-        </Card>
-      )}
-    </Box>
+              <CompactRecipeRecommendations
+                userId={userId}
+                limit={3}
+                orientation="vertical"
+              />
+            </Stack>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Stack>
   );
 }

--- a/src/components/tea/TeaDetails.tsx
+++ b/src/components/tea/TeaDetails.tsx
@@ -1,110 +1,180 @@
-import type { FragmentOf } from "@cellar-assistant/shared";
-import { readFragment } from "@cellar-assistant/shared";
-import { Box, Card, CardContent, Chip, Typography } from "@mui/joy";
-import { ItemBrands } from "../item/ItemBrands";
-import { ItemCard } from "../item/ItemCard";
-import { ItemRecipes } from "../item/ItemRecipes";
-import { TeaDetailsFragment } from "./fragments";
+import { type FragmentOf, readFragment } from "@cellar-assistant/shared";
+import { formatCountry, formatEnum } from "@cellar-assistant/shared/utility";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { notFound } from "next/navigation";
+import { isNil, isNotNil, nth } from "ramda";
+import { ItemBrands } from "@/components/item/ItemBrands";
+import { ItemCellars } from "@/components/item/ItemCellars";
+import ItemDetails from "@/components/item/ItemDetails";
+import { ItemHeaderServer } from "@/components/item/ItemHeaderServer";
+import { ItemImage } from "@/components/item/ItemImage";
+import { ItemRecipes } from "@/components/item/ItemRecipes";
+import { ItemReviews } from "@/components/item/ItemReviews";
+import { ItemShare } from "@/components/item/ItemShare";
+import { ItemTierLists } from "@/components/item/ItemTierLists";
+import { CompactRecipeRecommendations } from "@/components/recipe/RecipeRecommendations";
+import { AddReview } from "@/components/review/AddReview";
+import tea1 from "@/images/tea1.png";
+import {
+  TeaCellarsFragment,
+  TeaCoreFragment,
+  type TeaDetailsFragment,
+  TeaImagesFragment,
+  TeaRelationshipsFragment,
+  TeaReviewsFragment,
+  TeaUserDataFragment,
+} from "./fragments";
 
 interface TeaDetailsProps {
   teaData: FragmentOf<typeof TeaDetailsFragment>;
+  cellars: Array<{ id: string; name: string }>;
+  itemId: string;
+  userId?: string;
 }
 
-export function TeaDetails({ teaData }: TeaDetailsProps) {
-  const tea = readFragment(TeaDetailsFragment, teaData);
+export function TeaDetails({
+  teaData,
+  cellars,
+  itemId,
+  userId,
+}: TeaDetailsProps) {
+  if (isNil(teaData)) {
+    notFound();
+  }
+
+  const coreData = readFragment(TeaCoreFragment, teaData);
+  const imageData = readFragment(TeaImagesFragment, teaData);
+  const userData = readFragment(TeaUserDataFragment, teaData);
+  const reviews = readFragment(TeaReviewsFragment, teaData);
+  const cellarItems = readFragment(TeaCellarsFragment, teaData);
+  const relationships = readFragment(TeaRelationshipsFragment, teaData);
+
+  const displayImage = nth(0, imageData.item_images ?? []);
 
   const characteristics = [
-    { label: "Category", value: tea.category },
-    { label: "Form", value: tea.form },
-    { label: "Caffeine", value: tea.caffeine_level },
-    { label: "Oxidation", value: tea.oxidation_level },
-    { label: "Processing", value: tea.processing },
-    { label: "Cultivar", value: tea.cultivar },
-    { label: "Harvest Year", value: tea.harvest_year },
-    { label: "Steep Temp", value: tea.steeping_temperature },
-    { label: "Steep Time", value: tea.steeping_time },
-    { label: "Country", value: tea.country },
-    { label: "Region", value: tea.region },
-    { label: "Organic", value: tea.is_organic ? "Yes" : undefined },
-    { label: "Fair Trade", value: tea.is_fair_trade ? "Yes" : undefined },
-  ].filter((item) => item.value !== null && item.value !== undefined);
+    { label: "Category", value: formatEnum(coreData.category) },
+    { label: "Form", value: formatEnum(coreData.form) },
+    { label: "Caffeine", value: formatEnum(coreData.caffeine_level) },
+    { label: "Oxidation", value: formatEnum(coreData.oxidation_level) },
+    { label: "Processing", value: formatEnum(coreData.processing) },
+    { label: "Cultivar", value: coreData.cultivar },
+    { label: "Harvest Year", value: coreData.harvest_year },
+    { label: "Steep Temp", value: coreData.steeping_temperature },
+    { label: "Steep Time", value: coreData.steeping_time },
+    { label: "Organic", value: coreData.is_organic ? "Yes" : undefined },
+    { label: "Fair Trade", value: coreData.is_fair_trade ? "Yes" : undefined },
+  ].filter((char) => isNotNil(char.value) && char.value !== "");
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
-      {/* Main item card */}
-      <ItemCard
-        item={{
-          id: tea.id,
-          itemId: tea.id,
-          name: tea.name,
-        }}
-        type={"TEA"}
+    <Stack spacing={2}>
+      <ItemHeaderServer
+        itemId={itemId}
+        itemName={coreData.name}
+        itemType={"TEA"}
+        cellars={cellars}
       />
+      <Grid container spacing={2}>
+        <Grid xs={12} sm={4}>
+          <Stack spacing={1}>
+            <ItemImage
+              fileId={displayImage?.file_id}
+              placeholder={displayImage?.placeholder}
+              fallback={tea1}
+            />
+            <ItemShare itemId={coreData.id} itemType={"TEA"} />
+          </Stack>
+        </Grid>
+        <Grid container xs={12} sm={8}>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <ItemDetails
+                itemId={coreData.id}
+                type={"TEA"}
+                favoriteId={nth(0, userData.item_favorites)?.id}
+                title={coreData.name}
+                subTitlePhrases={[
+                  formatEnum(coreData.category),
+                  formatEnum(coreData.form),
+                  formatCountry(coreData.country),
+                  coreData.region,
+                ]}
+                description={coreData.description}
+              />
+              {characteristics.length > 0 && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Tea Characteristics
+                    </Typography>
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                      {characteristics.map((char) => (
+                        <Chip key={char.label} variant="outlined">
+                          {char.label}: {char.value}
+                        </Chip>
+                      ))}
+                    </Box>
+                  </CardContent>
+                </Card>
+              )}
+              {coreData.flavor_profile && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Flavor Profile
+                    </Typography>
+                    <Typography>{coreData.flavor_profile}</Typography>
+                  </CardContent>
+                </Card>
+              )}
+              {coreData.ingredients && (
+                <Card>
+                  <CardContent>
+                    <Typography level="title-lg" sx={{ mb: 1 }}>
+                      Ingredients
+                    </Typography>
+                    <Typography>{coreData.ingredients}</Typography>
+                  </CardContent>
+                </Card>
+              )}
+              <ItemCellars
+                cellars={cellarItems.cellar_items.map((x) => ({
+                  ...x.cellar,
+                  co_owners: x.cellar.co_owners.map((y) => y.user),
+                }))}
+              />
+              <ItemTierLists entityId={coreData.id} entityType="tea" />
+            </Stack>
+          </Grid>
+          <Grid xs={12} sm={12} lg={6}>
+            <Stack spacing={2}>
+              <AddReview teaId={coreData.id} />
+              <ItemReviews reviews={reviews.reviews} />
 
-      {/* Tea characteristics */}
-      <Card>
-        <CardContent>
-          <Typography level="h3" sx={{ mb: 2 }}>
-            Tea Characteristics
-          </Typography>
-          <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-            {characteristics.map((char) => (
-              <Chip key={char.label} variant="outlined">
-                {char.label}: {char.value}
-              </Chip>
-            ))}
-          </Box>
-        </CardContent>
-      </Card>
+              <ItemBrands brands={relationships.brands} title="Tea Brands" />
 
-      {/* Brands */}
-      {tea.brands && tea.brands.length > 0 && (
-        <ItemBrands brands={tea.brands} />
-      )}
+              <ItemRecipes
+                recipeIngredients={relationships.recipe_ingredients}
+                title="Used in Recipes"
+                itemName={coreData.name}
+              />
 
-      {/* Recipes */}
-      {tea.recipe_ingredients && tea.recipe_ingredients.length > 0 && (
-        <ItemRecipes
-          recipeIngredients={tea.recipe_ingredients}
-          itemName={tea.name}
-        />
-      )}
-
-      {/* Ingredients */}
-      {tea.ingredients && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Ingredients
-            </Typography>
-            <Typography>{tea.ingredients}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Flavor profile */}
-      {tea.flavor_profile && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Flavor Profile
-            </Typography>
-            <Typography>{tea.flavor_profile}</Typography>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Description */}
-      {tea.description && (
-        <Card>
-          <CardContent>
-            <Typography level="h3" sx={{ mb: 1 }}>
-              Description
-            </Typography>
-            <Typography>{tea.description}</Typography>
-          </CardContent>
-        </Card>
-      )}
-    </Box>
+              <CompactRecipeRecommendations
+                userId={userId}
+                limit={3}
+                orientation="vertical"
+              />
+            </Stack>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Stack>
   );
 }


### PR DESCRIPTION
## What

Aligns the **standalone (non-cellar)** tea and sake detail pages — `/teas/[itemId]` and `/sakes/[itemId]` — with wine/beer/spirit/coffee. Follow-up to #596, which fixed the cellar-scoped pages; these standalone routes had the same simplified placeholder layout.

## Why

The standalone pages render `TeaDetails.tsx` / `SakeDetails.tsx` (distinct from the `Cellar*Details.tsx` components fixed in #596). Both were a single-column `ItemCard` + characteristic chips with no header, image, reviews, cellars, or tier lists, and broken responsiveness — clearly out of place next to the other item types.

The backend already supported everything needed (reviews, favorites, image upload, `tea`/`sake` tier-list entity types); the gap was front-end only.

## Changes

**Components** — `TeaDetails` / `SakeDetails` rewritten to mirror `WineDetails`:
- `ItemHeaderServer` (add-to-cellar actions)
- Responsive MUI `Grid` two-column layout
- `ItemImage` + `ItemShare` (left column)
- `ItemDetails`, a type-specific characteristics chip card, `ItemCellars`, `ItemTierLists`
- `AddReview` + `ItemReviews` + `ItemBrands` + `ItemRecipes` + `CompactRecipeRecommendations` (right column)

**Page routes** — `/teas/[itemId]` and `/sakes/[itemId]` now pass `cellars` and `itemId` to the components (the GraphQL queries already returned `cellars`).

`ItemTierLists` already supported `tea`/`sake` entity types — no change needed.

## Verification

- `pnpm typecheck`: **no new type errors** (only the pre-existing fresh-worktree `@/images/*.png` TS2307 baseline, present identically across all detail components).
- Biome-formatted.
- No live browser pass — no dev server was reachable during the change. Worth a manual look at a standalone tea and sake item to confirm the header, image, review box, and responsive layout render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)