### PR TITLE
feat: add items to tier lists from item & place detail pages

### DIFF
--- a/src/app/(authenticated)/beers/[itemId]/page.tsx
+++ b/src/app/(authenticated)/beers/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function BeerDetailsPage({
       beer={data.beers_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/app/(authenticated)/coffees/[itemId]/page.tsx
+++ b/src/app/(authenticated)/coffees/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function CoffeeDetailsPage({
       coffee={data.coffees_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/app/(authenticated)/places/[placeId]/page.tsx
+++ b/src/app/(authenticated)/places/[placeId]/page.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, Typography } from "@mui/joy";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
+import { ItemTierLists } from "@/components/item/ItemTierLists";
 import { PlaceDetails } from "@/components/map/places/PlaceDetails";
 import { getServerUserId } from "@/utilities/auth-server";
 import { serverQuery } from "@/lib/urql/server";
@@ -84,6 +85,7 @@ export default async function PlaceDetailsPage({
           userId={userId}
           serverEnrichment={serverEnrichment}
           serverPhotos={serverPhotos}
+          tierLists={<ItemTierLists entityId={placeId} entityType="place" />}
         />
       </Suspense>
     </Box>

--- a/src/app/(authenticated)/sakes/[itemId]/page.tsx
+++ b/src/app/(authenticated)/sakes/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function SakeDetailsPage({
       sakeData={data.sakes_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/app/(authenticated)/spirits/[itemId]/page.tsx
+++ b/src/app/(authenticated)/spirits/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function SpiritDetailsPage({
       spirit={data.spirits_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/app/(authenticated)/teas/[itemId]/page.tsx
+++ b/src/app/(authenticated)/teas/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function TeaDetailsPage({
       teaData={data.teas_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/app/(authenticated)/wines/[itemId]/page.tsx
+++ b/src/app/(authenticated)/wines/[itemId]/page.tsx
@@ -23,6 +23,7 @@ export default async function WineDetailsPage({
       wine={data.wines_by_pk}
       cellars={data.cellars}
       itemId={itemId}
+      userId={userId}
     />
   );
 }

--- a/src/components/beer/BeerDetails.tsx
+++ b/src/components/beer/BeerDetails.tsx
@@ -31,9 +31,15 @@ interface BeerDetailsProps {
   beer: FragmentOf<typeof BeerDetailsFragment>;
   cellars: Array<{ id: string; name: string }>;
   itemId: string;
+  userId?: string;
 }
 
-export function BeerDetails({ beer, cellars, itemId }: BeerDetailsProps) {
+export function BeerDetails({
+  beer,
+  cellars,
+  itemId,
+  userId,
+}: BeerDetailsProps) {
   if (isNil(beer)) {
     notFound();
   }
@@ -54,6 +60,7 @@ export function BeerDetails({ beer, cellars, itemId }: BeerDetailsProps) {
         itemId={itemId}
         itemName={coreData.name}
         itemType={"BEER"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>

--- a/src/components/beer/CellarBeerDetails.tsx
+++ b/src/components/beer/CellarBeerDetails.tsx
@@ -80,6 +80,7 @@ export function CellarBeerDetails({
       <CellarItemHeader
         itemType={"BEER"}
         itemId={itemId}
+        entityId={beerCore?.id ?? ""}
         itemName={itemName || beerCore?.name}
         cellarId={cellarId}
         cellarName={cellarName || itemData.cellar?.name}

--- a/src/components/coffee/CellarCoffeeDetails.tsx
+++ b/src/components/coffee/CellarCoffeeDetails.tsx
@@ -83,6 +83,7 @@ export function CellarCoffeeDetails({
       <CellarItemHeader
         itemType={"COFFEE"}
         itemId={itemId}
+        entityId={coffeeCore?.id ?? ""}
         itemName={itemName || coffeeCore?.name}
         cellarId={cellarId}
         cellarName={cellarName || itemData.cellar?.name}

--- a/src/components/coffee/CoffeeDetails.tsx
+++ b/src/components/coffee/CoffeeDetails.tsx
@@ -27,9 +27,15 @@ interface CoffeeDetailsProps {
   coffee: FragmentOf<typeof CoffeeDetailsFragment>;
   cellars: Array<{ id: string; name: string }>;
   itemId: string;
+  userId?: string;
 }
 
-export function CoffeeDetails({ coffee, cellars, itemId }: CoffeeDetailsProps) {
+export function CoffeeDetails({
+  coffee,
+  cellars,
+  itemId,
+  userId,
+}: CoffeeDetailsProps) {
   if (isNil(coffee)) {
     notFound();
   }
@@ -50,6 +56,7 @@ export function CoffeeDetails({ coffee, cellars, itemId }: CoffeeDetailsProps) {
         itemId={itemId}
         itemName={coreData.name}
         itemType={"COFFEE"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>

--- a/src/components/item/CellarItemHeader.tsx
+++ b/src/components/item/CellarItemHeader.tsx
@@ -16,11 +16,15 @@ import { useState, useTransition } from "react";
 import { MdDelete, MdEdit, MdWarning } from "react-icons/md";
 import { deleteCellarItemAction } from "@/app/actions/cellarItems";
 import { HeaderBar } from "@/components/common/HeaderBar";
+import { AddToTierListButton } from "@/components/tier-list/AddToTierListButton";
+import type { TierListEntityType } from "@/components/tier-list/constants";
 import { formatItemType } from "@/utilities";
 import { Link } from "../common/Link";
 
 type CellarItemHeaderProps = {
   itemId: string;
+  /** The underlying catalog item id (wine/beer/…), used for tier lists. */
+  entityId: string;
   itemName: string | undefined;
   itemType: ItemTypeValue;
   cellarId: string;
@@ -32,10 +36,12 @@ type CellarItemHeaderProps = {
 export const CellarItemHeader = ({
   itemType,
   itemId,
+  entityId,
   itemName,
   cellarId,
   cellarName,
   isOwner,
+  userId,
 }: CellarItemHeaderProps) => {
   const router = useRouter();
   const [open, setOpen] = useState(false);
@@ -63,6 +69,12 @@ export const CellarItemHeader = ({
         }}
         endComponent={
           <Stack spacing={2} direction="row">
+            <AddToTierListButton
+              entityId={entityId}
+              entityType={itemType.toLowerCase() as TierListEntityType}
+              entityName={itemName ?? "this item"}
+              userId={userId}
+            />
             <Button
               component={Link}
               href={`${itemId}/edit`}

--- a/src/components/item/ItemHeaderServer.tsx
+++ b/src/components/item/ItemHeaderServer.tsx
@@ -1,12 +1,15 @@
 import type { ItemTypeValue } from "@cellar-assistant/shared";
 import { Stack } from "@mui/joy";
 import { HeaderBar } from "@/components/common/HeaderBar";
+import { AddToTierListButton } from "@/components/tier-list/AddToTierListButton";
+import type { TierListEntityType } from "@/components/tier-list/constants";
 import { AddToCellarActions } from "./AddToCellarActions";
 
 type ItemHeaderServerProps = {
   itemId: string;
   itemName?: string;
   itemType: ItemTypeValue;
+  userId?: string;
   cellars?: {
     id: string;
     name: string;
@@ -17,6 +20,7 @@ export const ItemHeaderServer = ({
   itemType,
   itemId,
   itemName,
+  userId,
   cellars,
 }: ItemHeaderServerProps) => {
   return (
@@ -26,6 +30,14 @@ export const ItemHeaderServer = ({
       }}
       endComponent={
         <Stack spacing={2} direction="row">
+          {userId && (
+            <AddToTierListButton
+              entityId={itemId}
+              entityType={itemType.toLowerCase() as TierListEntityType}
+              entityName={itemName ?? "this item"}
+              userId={userId}
+            />
+          )}
           <AddToCellarActions
             itemType={itemType}
             itemId={itemId}

--- a/src/components/item/ItemTierLists.tsx
+++ b/src/components/item/ItemTierLists.tsx
@@ -1,11 +1,13 @@
-"use client";
-
 import { graphql } from "@cellar-assistant/shared";
 import { Card, CardContent, Chip, Stack, Typography } from "@mui/joy";
 import { MdFormatListNumbered } from "react-icons/md";
-import { useQuery } from "urql";
+import { serverQuery } from "@/lib/urql/server";
 import { Link } from "../common/Link";
-import { BAND_JOY_COLORS, BAND_LABELS } from "../tier-list/constants";
+import {
+  BAND_JOY_COLORS,
+  BAND_LABELS,
+  type TierListEntityType,
+} from "../tier-list/constants";
 
 const GetTierListsForEntityQuery = graphql(`
   query GetTierListsForEntity(
@@ -40,23 +42,14 @@ const GetTierListsForEntityQuery = graphql(`
   }
 `);
 
-type EntityType =
-  | "place"
-  | "wine"
-  | "beer"
-  | "spirit"
-  | "coffee"
-  | "sake"
-  | "tea";
-
 interface ItemTierListsProps {
   entityId: string;
-  entityType: EntityType;
+  entityType: TierListEntityType;
 }
 
 const NIL_UUID = "00000000-0000-0000-0000-000000000000";
 
-function buildVariables(entityId: string, entityType: EntityType) {
+function buildVariables(entityId: string, entityType: TierListEntityType) {
   return {
     placeId: entityType === "place" ? entityId : NIL_UUID,
     wineId: entityType === "wine" ? entityId : NIL_UUID,
@@ -68,15 +61,23 @@ function buildVariables(entityId: string, entityType: EntityType) {
   };
 }
 
-export function ItemTierLists({ entityId, entityType }: ItemTierListsProps) {
-  const [{ data, fetching }] = useQuery({
-    query: GetTierListsForEntityQuery,
-    variables: buildVariables(entityId, entityType),
-  });
+/**
+ * Server component showing which tier lists an entity already appears on.
+ * Fetched server-side so it re-renders on router.refresh() (e.g. after the
+ * "Add to Tier List" modal adds the item).
+ */
+export async function ItemTierLists({
+  entityId,
+  entityType,
+}: ItemTierListsProps) {
+  const data = await serverQuery(
+    GetTierListsForEntityQuery,
+    buildVariables(entityId, entityType),
+  );
 
   const items = data?.tier_list_items ?? [];
 
-  if (fetching || items.length === 0) {
+  if (items.length === 0) {
     return null;
   }
 

--- a/src/components/map/places/PlaceDetails.tsx
+++ b/src/components/map/places/PlaceDetails.tsx
@@ -956,6 +956,7 @@ export function PlaceDetails({
         entityId={placeData.id}
         entityType="place"
         entityName={placeData.name}
+        userId={userId}
       />
     </Box>
   );

--- a/src/components/map/places/PlaceDetails.tsx
+++ b/src/components/map/places/PlaceDetails.tsx
@@ -40,7 +40,7 @@ import {
 } from "@mui/joy";
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { MdFormatListNumbered } from "react-icons/md";
 import { useMutation, useQuery } from "urql";
 import {
@@ -49,7 +49,6 @@ import {
   PlaceWithMenuFragment,
 } from "../../shared/fragments/place-fragments";
 import { AddToTierListModal } from "../../tier-list/AddToTierListModal";
-import { ItemTierLists } from "../../item/ItemTierLists";
 import {
   GET_PLACE_DETAILS,
   MARK_PLACE_VISITED,
@@ -223,6 +222,8 @@ interface PlaceDetailsProps {
   userId: string;
   serverEnrichment?: PlaceEnrichment | null;
   serverPhotos?: PlaceGooglePhoto[];
+  /** Server-rendered "On Lists" card, passed in so it can be an RSC. */
+  tierLists?: ReactNode;
 }
 
 export function PlaceDetails({
@@ -230,6 +231,7 @@ export function PlaceDetails({
   userId,
   serverEnrichment,
   serverPhotos,
+  tierLists,
 }: PlaceDetailsProps) {
   const [activeTab, setActiveTab] = useState(0);
   const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
@@ -809,10 +811,8 @@ export function PlaceDetails({
         </Card>
       )}
 
-      {/* Tier lists this place belongs to */}
-      <Box sx={{ mb: 3 }}>
-        <ItemTierLists entityId={placeData.id} entityType="place" />
-      </Box>
+      {/* Tier lists this place belongs to (server-rendered slot) */}
+      <Box sx={{ mb: 3 }}>{tierLists}</Box>
 
       {/* Google Attribution */}
       {enrichment && (
@@ -953,9 +953,9 @@ export function PlaceDetails({
       <AddToTierListModal
         open={tierListModalOpen}
         onClose={() => setTierListModalOpen(false)}
-        placeId={placeData.id}
-        placeName={placeData.name}
-        userId={userId}
+        entityId={placeData.id}
+        entityType="place"
+        entityName={placeData.name}
       />
     </Box>
   );

--- a/src/components/map/places/PlaceDetailsContent.tsx
+++ b/src/components/map/places/PlaceDetailsContent.tsx
@@ -760,9 +760,9 @@ export function PlaceDetailsContent({
       <AddToTierListModal
         open={tierListModalOpen}
         onClose={() => setTierListModalOpen(false)}
-        placeId={place.id}
-        placeName={place.name}
-        userId={userId}
+        entityId={place.id}
+        entityType="place"
+        entityName={place.name}
       />
     </>
   );

--- a/src/components/map/places/PlaceDetailsContent.tsx
+++ b/src/components/map/places/PlaceDetailsContent.tsx
@@ -763,6 +763,7 @@ export function PlaceDetailsContent({
         entityId={place.id}
         entityType="place"
         entityName={place.name}
+        userId={userId}
       />
     </>
   );

--- a/src/components/sake/CellarSakeDetails.tsx
+++ b/src/components/sake/CellarSakeDetails.tsx
@@ -91,6 +91,7 @@ export function CellarSakeDetails({
       <CellarItemHeader
         itemType={"SAKE"}
         itemId={itemId}
+        entityId={sake.id}
         itemName={itemName || sake.name}
         cellarId={cellarId}
         cellarName={cellarName || item.cellar?.name}

--- a/src/components/sake/SakeDetails.tsx
+++ b/src/components/sake/SakeDetails.tsx
@@ -86,6 +86,7 @@ export function SakeDetails({
         itemId={itemId}
         itemName={coreData.name}
         itemType={"SAKE"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>

--- a/src/components/spirit/CellarSpiritDetails.tsx
+++ b/src/components/spirit/CellarSpiritDetails.tsx
@@ -83,6 +83,7 @@ export function CellarSpiritDetails({
       <CellarItemHeader
         itemType={"SPIRIT"}
         itemId={itemId}
+        entityId={spiritCore?.id ?? ""}
         itemName={itemName || spiritCore?.name}
         cellarId={cellarId}
         cellarName={cellarName || itemData.cellar?.name}

--- a/src/components/spirit/SpiritDetails.tsx
+++ b/src/components/spirit/SpiritDetails.tsx
@@ -31,9 +31,15 @@ interface SpiritDetailsProps {
   spirit: FragmentOf<typeof SpiritDetailsFragment>;
   cellars: Array<{ id: string; name: string }>;
   itemId: string;
+  userId?: string;
 }
 
-export function SpiritDetails({ spirit, cellars, itemId }: SpiritDetailsProps) {
+export function SpiritDetails({
+  spirit,
+  cellars,
+  itemId,
+  userId,
+}: SpiritDetailsProps) {
   if (isNil(spirit)) {
     notFound();
   }
@@ -54,6 +60,7 @@ export function SpiritDetails({ spirit, cellars, itemId }: SpiritDetailsProps) {
         itemId={itemId}
         itemName={coreData.name}
         itemType={"SPIRIT"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>

--- a/src/components/tea/CellarTeaDetails.tsx
+++ b/src/components/tea/CellarTeaDetails.tsx
@@ -84,6 +84,7 @@ export function CellarTeaDetails({
       <CellarItemHeader
         itemType={"TEA"}
         itemId={itemId}
+        entityId={tea.id}
         itemName={itemName || tea.name}
         cellarId={cellarId}
         cellarName={cellarName || item.cellar?.name}

--- a/src/components/tea/TeaDetails.tsx
+++ b/src/components/tea/TeaDetails.tsx
@@ -79,6 +79,7 @@ export function TeaDetails({
         itemId={itemId}
         itemName={coreData.name}
         itemType={"TEA"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>

--- a/src/components/tier-list/AddToTierListButton.tsx
+++ b/src/components/tier-list/AddToTierListButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { Button } from "@mui/joy";
+import { useState } from "react";
+import { MdFormatListNumbered } from "react-icons/md";
+import { AddToTierListModal } from "./AddToTierListModal";
+import type { TierListEntityType } from "./constants";
+
+type AddToTierListButtonProps = {
+  entityId: string;
+  entityType: TierListEntityType;
+  entityName: string;
+  userId: string;
+};
+
+/**
+ * Trigger button + modal for adding an entity (item or place) to one of the
+ * current user's tier lists.
+ */
+export const AddToTierListButton = ({
+  entityId,
+  entityType,
+  entityName,
+  userId,
+}: AddToTierListButtonProps) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        color="neutral"
+        startDecorator={<MdFormatListNumbered />}
+        onClick={() => setOpen(true)}
+      >
+        Add to Tier List
+      </Button>
+      <AddToTierListModal
+        open={open}
+        onClose={() => setOpen(false)}
+        entityId={entityId}
+        entityType={entityType}
+        entityName={entityName}
+        userId={userId}
+      />
+    </>
+  );
+};

--- a/src/components/tier-list/AddToTierListModal.tsx
+++ b/src/components/tier-list/AddToTierListModal.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import type { Permission_Type_Enum } from "@cellar-assistant/shared";
 import {
   Box,
+  Button,
   CircularProgress,
   DialogContent,
   DialogTitle,
   Divider,
+  Input,
   List,
   ListItem,
   ListItemButton,
@@ -17,12 +20,52 @@ import {
   Stack,
   Typography,
 } from "@mui/joy";
-import { useCallback, useState } from "react";
-import { MdCheck, MdFormatListNumbered } from "react-icons/md";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { MdAdd, MdCheck, MdFormatListNumbered } from "react-icons/md";
 import { useQuery } from "urql";
-import { addItemToTierListAction } from "@/app/actions/tierLists";
-import { BAND_LABELS } from "./constants";
-import { GetTierListsForPlaceQuery } from "./queries";
+import {
+  addItemToTierListAction,
+  addTierListAction,
+} from "@/app/actions/tierLists";
+import { BAND_LABELS, type TierListEntityType } from "./constants";
+import { GetTierListsForItemQuery } from "./queries";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const ENTITY_TYPE_LABELS: Record<TierListEntityType, string> = {
+  place: "Place",
+  wine: "Wine",
+  beer: "Beer",
+  spirit: "Spirit",
+  coffee: "Coffee",
+  sake: "Sake",
+  tea: "Tea",
+};
+
+const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Build the polymorphic id variables for GetTierListsForItemQuery, setting the
+ * field that matches `entityType` and leaving the rest as the nil UUID so their
+ * `_eq` filters match nothing.
+ */
+function buildEntityIdVariables(
+  entityType: TierListEntityType,
+  entityId: string,
+) {
+  return {
+    placeId: entityType === "place" ? entityId : NIL_UUID,
+    wineId: entityType === "wine" ? entityId : NIL_UUID,
+    beerId: entityType === "beer" ? entityId : NIL_UUID,
+    spiritId: entityType === "spirit" ? entityId : NIL_UUID,
+    coffeeId: entityType === "coffee" ? entityId : NIL_UUID,
+    sakeId: entityType === "sake" ? entityId : NIL_UUID,
+    teaId: entityType === "tea" ? entityId : NIL_UUID,
+  };
+}
 
 // =============================================================================
 // Types
@@ -31,10 +74,10 @@ import { GetTierListsForPlaceQuery } from "./queries";
 interface AddToTierListModalProps {
   open: boolean;
   onClose: () => void;
-  placeId: string;
-  placeName: string;
+  entityId: string;
+  entityType: TierListEntityType;
+  entityName: string;
   userId: string;
-  existingRating?: number | null;
 }
 
 // =============================================================================
@@ -44,20 +87,39 @@ interface AddToTierListModalProps {
 export function AddToTierListModal({
   open,
   onClose,
-  placeId,
-  placeName,
+  entityId,
+  entityType,
+  entityName,
   userId,
 }: AddToTierListModalProps) {
+  const router = useRouter();
+
   const [{ data, fetching }] = useQuery({
-    query: GetTierListsForPlaceQuery,
-    variables: { placeId, userId },
+    query: GetTierListsForItemQuery,
+    variables: {
+      listType: entityType,
+      userId,
+      ...buildEntityIdVariables(entityType, entityId),
+    },
     pause: !open,
   });
 
   const [addingToListId, setAddingToListId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const [showCreate, setShowCreate] = useState(false);
+  const [newListName, setNewListName] = useState("");
+  const [creating, setCreating] = useState(false);
+
   const tierLists = data?.tier_lists ?? [];
+  const busy = addingToListId != null || creating;
+
+  // Reset the create form whenever the modal opens.
+  useEffect(() => {
+    if (!open) return;
+    setShowCreate(false);
+    setNewListName(`My ${ENTITY_TYPE_LABELS[entityType]} Tier List`);
+  }, [open, entityType]);
 
   const handleAddToList = useCallback(
     async (tierListId: string) => {
@@ -65,12 +127,13 @@ export function AddToTierListModal({
       try {
         const result = await addItemToTierListAction(
           tierListId,
-          placeId,
-          "place",
+          entityId,
+          entityType,
           0,
           0,
         );
         if (result.success) {
+          router.refresh();
           onClose();
         } else {
           setError(result.error ?? "Failed to add item to tier list");
@@ -79,8 +142,46 @@ export function AddToTierListModal({
         setAddingToListId(null);
       }
     },
-    [placeId, onClose],
+    [entityId, entityType, onClose, router],
   );
+
+  const handleCreateAndAdd = useCallback(async () => {
+    const name = newListName.trim();
+    if (name.length === 0) {
+      setError("Please enter a name for the new list");
+      return;
+    }
+    setCreating(true);
+    try {
+      const created = await addTierListAction(
+        name,
+        undefined,
+        "PRIVATE" as Permission_Type_Enum,
+        entityType,
+      );
+      if (!created.success || !created.tierListId) {
+        setError(created.error ?? "Failed to create tier list");
+        return;
+      }
+      const added = await addItemToTierListAction(
+        created.tierListId,
+        entityId,
+        entityType,
+        0,
+        0,
+      );
+      if (added.success) {
+        router.refresh();
+        onClose();
+      } else {
+        setError(added.error ?? "Failed to add item to tier list");
+      }
+    } finally {
+      setCreating(false);
+    }
+  }, [newListName, entityId, entityType, onClose, router]);
+
+  const hasLists = tierLists.length > 0;
 
   return (
     <>
@@ -96,74 +197,134 @@ export function AddToTierListModal({
           <DialogContent>
             <Stack spacing={2}>
               <Typography level="body-sm" sx={{ color: "text.secondary" }}>
-                Add <strong>{placeName}</strong> to a tier list
+                Add <strong>{entityName}</strong> to a tier list
               </Typography>
 
               {fetching ? (
                 <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
                   <CircularProgress size="sm" />
                 </Box>
-              ) : tierLists.length === 0 ? (
-                <Typography
-                  level="body-sm"
-                  sx={{ color: "text.tertiary", textAlign: "center", py: 2 }}
-                >
-                  No place tier lists yet. Create one first.
-                </Typography>
               ) : (
-                <List
-                  size="sm"
-                  variant="outlined"
-                  sx={{ borderRadius: "md", overflow: "hidden" }}
-                >
-                  {tierLists.map((tl) => {
-                    const alreadyIn = tl.items.length > 0;
-                    const isAdding = addingToListId === tl.id;
-                    return (
-                      <ListItem key={tl.id}>
-                        <ListItemButton
-                          onClick={() => handleAddToList(tl.id)}
-                          disabled={alreadyIn || addingToListId != null}
-                          sx={{
-                            borderRadius: "sm",
-                            ...(alreadyIn && {
-                              bgcolor: "success.softBg",
-                              "&.Mui-disabled": { opacity: 1 },
-                            }),
-                          }}
+                <>
+                  {hasLists && (
+                    <List
+                      size="sm"
+                      variant="outlined"
+                      sx={{ borderRadius: "md", overflow: "hidden" }}
+                    >
+                      {tierLists.map((tl) => {
+                        const alreadyIn = tl.items.length > 0;
+                        const isAdding = addingToListId === tl.id;
+                        return (
+                          <ListItem key={tl.id}>
+                            <ListItemButton
+                              onClick={() => handleAddToList(tl.id)}
+                              disabled={alreadyIn || busy}
+                              sx={{
+                                borderRadius: "sm",
+                                ...(alreadyIn && {
+                                  bgcolor: "success.softBg",
+                                  "&.Mui-disabled": { opacity: 1 },
+                                }),
+                              }}
+                            >
+                              <ListItemDecorator>
+                                {isAdding ? (
+                                  <CircularProgress
+                                    size="sm"
+                                    sx={{ "--CircularProgress-size": "20px" }}
+                                  />
+                                ) : alreadyIn ? (
+                                  <MdCheck
+                                    style={{
+                                      color: "var(--joy-palette-success-500)",
+                                    }}
+                                  />
+                                ) : (
+                                  <MdFormatListNumbered />
+                                )}
+                              </ListItemDecorator>
+                              <ListItemContent>
+                                <Typography level="title-sm">
+                                  {tl.name}
+                                </Typography>
+                                {alreadyIn && (
+                                  <Typography
+                                    level="body-xs"
+                                    sx={{ color: "success.600" }}
+                                  >
+                                    Already added (
+                                    {BAND_LABELS[tl.items[0].band]})
+                                  </Typography>
+                                )}
+                              </ListItemContent>
+                            </ListItemButton>
+                          </ListItem>
+                        );
+                      })}
+                    </List>
+                  )}
+
+                  {!hasLists && !showCreate && (
+                    <Typography
+                      level="body-sm"
+                      sx={{ color: "text.tertiary", textAlign: "center" }}
+                    >
+                      You don't have any{" "}
+                      {ENTITY_TYPE_LABELS[entityType].toLowerCase()} tier lists
+                      yet.
+                    </Typography>
+                  )}
+
+                  {showCreate ? (
+                    <Stack spacing={1}>
+                      <Input
+                        autoFocus
+                        size="sm"
+                        placeholder="List name"
+                        value={newListName}
+                        onChange={(e) => setNewListName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" && !busy) {
+                            void handleCreateAndAdd();
+                          }
+                        }}
+                        disabled={busy}
+                      />
+                      <Stack direction="row" spacing={1}>
+                        <Button
+                          size="sm"
+                          startDecorator={<MdAdd />}
+                          loading={creating}
+                          disabled={busy}
+                          onClick={() => void handleCreateAndAdd()}
                         >
-                          <ListItemDecorator>
-                            {isAdding ? (
-                              <CircularProgress
-                                size="sm"
-                                sx={{ "--CircularProgress-size": "20px" }}
-                              />
-                            ) : alreadyIn ? (
-                              <MdCheck
-                                style={{
-                                  color: "var(--joy-palette-success-500)",
-                                }}
-                              />
-                            ) : (
-                              <MdFormatListNumbered />
-                            )}
-                          </ListItemDecorator>
-                          <ListItemContent>
-                            <Typography level="title-sm">{tl.name}</Typography>
-                            {alreadyIn && (
-                              <Typography
-                                level="body-xs"
-                                sx={{ color: "success.600" }}
-                              >
-                                Already added ({BAND_LABELS[tl.items[0].band]})
-                              </Typography>
-                            )}
-                          </ListItemContent>
-                        </ListItemButton>
-                      </ListItem>
-                    );
-                  })}
-                </List>
+                          Create &amp; add
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="plain"
+                          color="neutral"
+                          disabled={busy}
+                          onClick={() => setShowCreate(false)}
+                        >
+                          Cancel
+                        </Button>
+                      </Stack>
+                    </Stack>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outlined"
+                      color="neutral"
+                      startDecorator={<MdAdd />}
+                      disabled={busy}
+                      onClick={() => setShowCreate(true)}
+                    >
+                      Create new list
+                    </Button>
+                  )}
+                </>
               )}
             </Stack>
           </DialogContent>

--- a/src/components/tier-list/constants.ts
+++ b/src/components/tier-list/constants.ts
@@ -15,3 +15,13 @@ export const BAND_JOY_COLORS: Record<number, ColorPaletteProp> = {
   1: "danger",
   0: "neutral",
 };
+
+/** Entity types that can be added to a tier list (matches tier_lists.list_type). */
+export type TierListEntityType =
+  | "place"
+  | "wine"
+  | "beer"
+  | "spirit"
+  | "coffee"
+  | "sake"
+  | "tea";

--- a/src/components/tier-list/queries.ts
+++ b/src/components/tier-list/queries.ts
@@ -48,38 +48,16 @@ export const GetTierListEditQuery = graphql(
 );
 
 /**
- * Get user's tier lists that may contain a specific place
- * Used by the "Add to Tier List" modal
- */
-export const GetTierListsForPlaceQuery = graphql(`
-  query GetTierListsForPlace($placeId: uuid!, $userId: uuid!) {
-    tier_lists(
-      where: {
-        list_type: { _eq: "place" }
-        created_by_id: { _eq: $userId }
-      }
-      order_by: { updated_at: desc }
-    ) {
-      id
-      name
-      list_type
-      items(where: { place_id: { _eq: $placeId } }) {
-        id
-        band
-      }
-    }
-  }
-`);
-
-/**
- * Get user's tier lists that may contain a specific item
- * Used by the "Add to Tier List" modal for wines, beers, etc.
- * Filters by list_type to only show relevant tier lists.
+ * Get the current user's tier lists of a given type, annotated with whether
+ * each already contains a specific entity (place/wine/beer/…).
+ * Used by the "Add to Tier List" modal across all entity types.
+ * Filters by list_type so only relevant tier lists are shown.
  */
 export const GetTierListsForItemQuery = graphql(`
   query GetTierListsForItem(
     $listType: String!
     $userId: uuid!
+    $placeId: uuid
     $wineId: uuid
     $beerId: uuid
     $spiritId: uuid
@@ -100,6 +78,7 @@ export const GetTierListsForItemQuery = graphql(`
       items(
         where: {
           _or: [
+            { place_id: { _eq: $placeId } }
             { wine_id: { _eq: $wineId } }
             { beer_id: { _eq: $beerId } }
             { spirit_id: { _eq: $spiritId } }

--- a/src/components/wine/CellarWineDetails.tsx
+++ b/src/components/wine/CellarWineDetails.tsx
@@ -80,6 +80,7 @@ export function CellarWineDetails({
       <CellarItemHeader
         itemType={"WINE"}
         itemId={itemId}
+        entityId={wineCore?.id ?? ""}
         itemName={itemName || wineCore?.name}
         cellarId={cellarId}
         cellarName={cellarName || itemData.cellar?.name}

--- a/src/components/wine/WineDetails.tsx
+++ b/src/components/wine/WineDetails.tsx
@@ -62,6 +62,7 @@ export function WineDetails({
         itemId={itemId}
         itemName={coreData.name}
         itemType={"WINE"}
+        userId={userId}
         cellars={cellars}
       />
       <Grid container spacing={2}>


### PR DESCRIPTION
## What & why

Previously, items could only be added to a tier list from **place** detail pages. This adds an **"Add to Tier List"** action to the **item** detail pages — both the standalone (`/wines/[id]`, etc.) and cellar (`/cellars/[id]/wines/[id]`, etc.) variants — for all six item types (wine, beer, spirit, coffee, sake, tea), plus an inline **"Create new list"** flow so users with no matching list aren't dead-ended.

## What changed

- **Generalized `AddToTierListModal`** from place-only (`placeId`/`placeName`) to any entity (`entityId`/`entityType`/`entityName`). Keeps the existing pattern (urql `useQuery` + `userId` prop) rather than introducing a new data path. Adds an inline create flow that creates a `list_type`-matched list and adds the item (band 0 / **Unrated**) in one step.
- **New `AddToTierListButton`** (trigger + modal) wired into `ItemHeaderServer` (standalone pages) and `CellarItemHeader` (cellar pages). `userId`/`entityId` are threaded through the page → `*Details` → header chain.
  - ⚠️ For cellar items, the **underlying catalog id** (`wineCore.id`, …) is passed for tier-list membership — not the `cellar_item` id.
- **`ItemTierLists` ("On Lists" card) converted from a client urql component to an async server component** (`serverQuery`). It now re-renders on `router.refresh()` after an add, so the card reflects the change immediately. `PlaceDetails` stays `"use client"` (genuinely interactive — tabs, favorite/visit mutations, native share) and receives the card via an **RSC slot prop**, so we still get a server component with no duplication.
- Extended `GetTierListsForItemQuery` with a `placeId` variable and moved `TierListEntityType` into `tier-list/constants.ts` so the unified modal covers places too.

## Consistency with existing patterns

Button styling, the danger Snackbar on error, and `router.refresh()` on success all match the existing places/`TierListView` conventions.

## Side effect

Threading `userId` into `WineDetails`/`SakeDetails`/`TeaDetails` also fixes a pre-existing gap where `CompactRecipeRecommendations` was receiving `undefined` for `userId`.

## Testing

- `pnpm typecheck` (tsc --noEmit): **0 errors**
- `biome lint` on all changed/new files: **clean**

> Not yet verified in-browser; happy to run the end-to-end flow (add → create-list → lands in Unrated) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)