### PR TITLE
fix(migrations): make place_vectors 768 conversion safe on fresh replays

### DIFF
--- a/nhost/migrations/default/1741795200001_convert_place_vectors_768/down.sql
+++ b/nhost/migrations/default/1741795200001_convert_place_vectors_768/down.sql
@@ -1,39 +1,38 @@
--- Revert place_vectors from halfvec(768) back to halfvec(3072)
--- Reverses the Gemini Embedding 2 standardization
+-- Revert place_vectors from halfvec(768) back to halfvec(3072) — guarded.
+-- Reverses the Gemini Embedding 2 standardization.
+--
+-- Because this migration is mis-timestamped (1741795200001), in a full reverse
+-- rollback it runs LAST — after 1757471890000's down has already dropped the
+-- table. The guard below makes that a clean no-op instead of an error.
 
--- Drop the 768-dimension distance function
-DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(768));
+DO $do$
+BEGIN
+  IF to_regclass('public.place_vectors') IS NULL THEN
+    RAISE NOTICE 'place_vectors does not exist; nothing to revert.';
+    RETURN;
+  END IF;
 
--- Drop the 768-dimension HNSW indexes
-DROP INDEX IF EXISTS "public"."idx_place_vectors_hnsw";
-DROP INDEX IF EXISTS "public"."idx_place_vectors_hnsw_l2";
+  EXECUTE 'DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(768))';
+  EXECUTE 'DROP INDEX IF EXISTS public.idx_place_vectors_hnsw';
+  EXECUTE 'DROP INDEX IF EXISTS public.idx_place_vectors_hnsw_l2';
 
--- Revert the vector column back to halfvec(3072)
-ALTER TABLE "public"."place_vectors"
-ALTER COLUMN "vector" TYPE halfvec(3072) USING vector::halfvec(3072);
+  EXECUTE 'ALTER TABLE public.place_vectors ALTER COLUMN vector TYPE halfvec(3072) USING vector::halfvec(3072)';
 
--- Recreate HNSW index for cosine similarity search (3072 dimensions)
-CREATE INDEX "idx_place_vectors_hnsw" ON "public"."place_vectors"
-USING hnsw ("vector" halfvec_cosine_ops)
-WITH (m = 16, ef_construction = 64);
+  EXECUTE 'CREATE INDEX idx_place_vectors_hnsw ON public.place_vectors USING hnsw (vector halfvec_cosine_ops) WITH (m = 16, ef_construction = 64)';
+  EXECUTE 'CREATE INDEX idx_place_vectors_hnsw_l2 ON public.place_vectors USING hnsw (vector halfvec_l2_ops) WITH (m = 16, ef_construction = 64)';
 
--- Recreate HNSW index for L2 distance search (3072 dimensions)
-CREATE INDEX "idx_place_vectors_hnsw_l2" ON "public"."place_vectors"
-USING hnsw ("vector" halfvec_l2_ops)
-WITH (m = 16, ef_construction = 64);
+  EXECUTE $fn$
+    CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(3072))
+    RETURNS double precision
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT place_vector.vector <=> search
+    $function$
+  $fn$;
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.calculate_place_vector_distance TO nhost_hasura';
 
--- Recreate the distance calculation function with halfvec(3072) signature
-CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(3072))
-RETURNS double precision
-LANGUAGE sql
-STABLE
-AS $function$
-  SELECT place_vector.vector <=> search
-$function$;
-
--- Grant execute permissions to nhost_hasura
-GRANT EXECUTE ON FUNCTION public.calculate_place_vector_distance TO nhost_hasura;
-
--- Restore original table and column comments
-COMMENT ON TABLE "public"."place_vectors" IS 'Stores halfvec(3072) embeddings for places with HNSW indexing for efficient similarity search';
-COMMENT ON COLUMN "public"."place_vectors"."vector" IS 'halfvec(3072) embedding with HNSW index support';
+  EXECUTE 'COMMENT ON TABLE public.place_vectors IS ''Stores halfvec(3072) embeddings for places with HNSW indexing for efficient similarity search''';
+  EXECUTE 'COMMENT ON COLUMN public.place_vectors.vector IS ''halfvec(3072) embedding with HNSW index support''';
+END
+$do$;

--- a/nhost/migrations/default/1741795200001_convert_place_vectors_768/up.sql
+++ b/nhost/migrations/default/1741795200001_convert_place_vectors_768/up.sql
@@ -1,42 +1,65 @@
--- Convert place_vectors from halfvec(3072) to halfvec(768)
--- Standardizing on 768 dimensions to match Gemini Embedding 2 output
--- Existing vectors will be truncated; all vectors will be regenerated
+-- Convert place_vectors to halfvec(768) — idempotent + guarded.
+--
+-- HISTORY NOTE: this migration carries timestamp 1741795200001 (Mar 2025),
+-- which sorts BEFORE 1757471890000_add_place_vectors_table (Sep 2025) — the
+-- migration that actually creates the table. On a fresh, from-scratch replay
+-- (local dev / CI / disaster-recovery) it therefore ran before the table
+-- existed and failed with: relation "public.place_vectors" does not exist.
+--
+-- Production already applied this migration in order, against an existing
+-- table, so its version number is deliberately left unchanged to avoid forcing
+-- a re-run (which would rebuild the HNSW indexes under a lock). The body is now
+-- fully guarded so a from-scratch replay is a clean no-op here: the final
+-- halfvec(768) shape is produced by 1757474282000_update_place_vectors_to_halfvec
+-- instead. The conversion below only executes on the (now non-existent) path
+-- where the table is present but still wider than 768 dimensions.
 
--- Drop the existing distance function that depends on the vector column type
-DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(3072));
+DO $do$
+BEGIN
+  -- Fresh replay: this migration sorts before table creation, so the table is
+  -- not there yet. Nothing to do — the later migration creates it at 768.
+  IF to_regclass('public.place_vectors') IS NULL THEN
+    RAISE NOTICE 'place_vectors does not exist yet; skipping 768 conversion (handled by 1757474282000).';
+    RETURN;
+  END IF;
 
--- Drop existing HNSW indexes before altering the column
-DROP INDEX IF EXISTS "public"."idx_place_vectors_hnsw";
-DROP INDEX IF EXISTS "public"."idx_place_vectors_hnsw_l2";
+  -- Already halfvec(768) (e.g. production, or a re-run): nothing to do.
+  IF (
+    SELECT format_type(atttypid, atttypmod)
+    FROM pg_attribute
+    WHERE attrelid = 'public.place_vectors'::regclass
+      AND attname = 'vector'
+      AND NOT attisdropped
+  ) = 'halfvec(768)' THEN
+    RAISE NOTICE 'place_vectors.vector already halfvec(768); nothing to do.';
+    RETURN;
+  END IF;
 
--- Alter the vector column from halfvec(3072) to halfvec(768)
--- Note: existing vector data will be truncated to 768 dimensions;
--- all vectors should be regenerated after this migration
-ALTER TABLE "public"."place_vectors"
-ALTER COLUMN "vector" TYPE halfvec(768) USING vector::halfvec(768);
+  -- Table exists but column is still wider than 768: perform the conversion.
+  -- Existing vectors are truncated to 768 dimensions and should be regenerated.
+  EXECUTE 'DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(3072))';
+  EXECUTE 'DROP INDEX IF EXISTS public.idx_place_vectors_hnsw';
+  EXECUTE 'DROP INDEX IF EXISTS public.idx_place_vectors_hnsw_l2';
 
--- Recreate HNSW index for cosine similarity search
-CREATE INDEX "idx_place_vectors_hnsw" ON "public"."place_vectors"
-USING hnsw ("vector" halfvec_cosine_ops)
-WITH (m = 16, ef_construction = 64);
+  EXECUTE 'ALTER TABLE public.place_vectors ALTER COLUMN vector TYPE halfvec(768) USING vector::halfvec(768)';
 
--- Recreate HNSW index for L2 distance search
-CREATE INDEX "idx_place_vectors_hnsw_l2" ON "public"."place_vectors"
-USING hnsw ("vector" halfvec_l2_ops)
-WITH (m = 16, ef_construction = 64);
+  EXECUTE 'CREATE INDEX idx_place_vectors_hnsw ON public.place_vectors USING hnsw (vector halfvec_cosine_ops) WITH (m = 16, ef_construction = 64)';
+  EXECUTE 'CREATE INDEX idx_place_vectors_hnsw_l2 ON public.place_vectors USING hnsw (vector halfvec_l2_ops) WITH (m = 16, ef_construction = 64)';
 
--- Recreate the distance calculation function with halfvec(768) signature
-CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(768))
-RETURNS double precision
-LANGUAGE sql
-STABLE
-AS $function$
-  SELECT place_vector.vector <=> search
-$function$;
+  EXECUTE $fn$
+    CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(768))
+    RETURNS double precision
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT place_vector.vector <=> search
+    $function$
+  $fn$;
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.calculate_place_vector_distance TO nhost_hasura';
 
--- Grant execute permissions to nhost_hasura
-GRANT EXECUTE ON FUNCTION public.calculate_place_vector_distance TO nhost_hasura;
+  EXECUTE 'COMMENT ON TABLE public.place_vectors IS ''Stores halfvec(768) embeddings for places with HNSW indexing for efficient similarity search (Gemini Embedding 2)''';
+  EXECUTE 'COMMENT ON COLUMN public.place_vectors.vector IS ''halfvec(768) embedding with HNSW index support''';
 
--- Update table and column comments to reflect new dimensions
-COMMENT ON TABLE "public"."place_vectors" IS 'Stores halfvec(768) embeddings for places with HNSW indexing for efficient similarity search (Gemini Embedding 2)';
-COMMENT ON COLUMN "public"."place_vectors"."vector" IS 'halfvec(768) embedding with HNSW index support';
+  RAISE NOTICE 'place_vectors.vector converted to halfvec(768).';
+END
+$do$;

--- a/nhost/migrations/default/1757474282000_update_place_vectors_to_halfvec/down.sql
+++ b/nhost/migrations/default/1757474282000_update_place_vectors_to_halfvec/down.sql
@@ -1,7 +1,8 @@
--- Rollback place_vectors table from halfvec(3072) back to vector(3072)
+-- Rollback place_vectors table from halfvec(768) back to vector(3072)
 -- This reverses the HNSW index optimization
 
--- Drop the function that uses halfvec
+-- Drop the function that uses halfvec (both possible widths, to be safe)
+DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(768));
 DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, halfvec(3072));
 
 -- Drop the HNSW indexes

--- a/nhost/migrations/default/1757474282000_update_place_vectors_to_halfvec/up.sql
+++ b/nhost/migrations/default/1757474282000_update_place_vectors_to_halfvec/up.sql
@@ -1,5 +1,13 @@
--- Update place_vectors table to use halfvec(3072) instead of vector(3072)
--- This enables creation of HNSW indexes for efficient similarity search
+-- Update place_vectors table to use halfvec instead of vector(3072)
+-- This enables creation of HNSW indexes for efficient similarity search.
+--
+-- NOTE: this migration targets halfvec(768) (Gemini Embedding 2 output).
+-- It previously targeted halfvec(3072) and was followed by
+-- 1741795200001_convert_place_vectors_768 to narrow it to 768. That follow-up
+-- migration is mis-timestamped (Mar 2025) and sorts before the table even
+-- exists, so on a fresh from-scratch replay it cannot do the conversion.
+-- Landing on 768 here keeps fresh replays correct; production already applied
+-- both migrations in order and is unaffected (neither is re-run).
 
 -- First, drop the existing function that depends on the vector column
 DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, vector(3072));
@@ -8,9 +16,9 @@ DROP FUNCTION IF EXISTS public.calculate_place_vector_distance(place_vectors, ve
 -- Note: This migration assumes the table is empty or has minimal data
 -- For production with large datasets, consider a more careful migration approach
 
--- Alter the vector column to use halfvec(3072)
-ALTER TABLE "public"."place_vectors" 
-ALTER COLUMN "vector" TYPE halfvec(3072) USING vector::halfvec(3072);
+-- Alter the vector column to use halfvec(768)
+ALTER TABLE "public"."place_vectors"
+ALTER COLUMN "vector" TYPE halfvec(768) USING vector::halfvec(768);
 
 -- Create HNSW index for efficient similarity search
 -- HNSW (Hierarchical Navigable Small World) is optimal for high-dimensional vectors
@@ -24,7 +32,7 @@ USING hnsw ("vector" halfvec_l2_ops)
 WITH (m = 16, ef_construction = 64);
 
 -- Recreate the distance calculation function with halfvec support
-CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(3072))
+CREATE OR REPLACE FUNCTION public.calculate_place_vector_distance(place_vector place_vectors, search halfvec(768))
 RETURNS double precision
 LANGUAGE sql
 STABLE
@@ -36,5 +44,5 @@ $function$;
 GRANT EXECUTE ON FUNCTION public.calculate_place_vector_distance TO nhost_hasura;
 
 -- Update table comment to reflect the change
-COMMENT ON TABLE "public"."place_vectors" IS 'Stores halfvec(3072) embeddings for places with HNSW indexing for efficient similarity search';
-COMMENT ON COLUMN "public"."place_vectors"."vector" IS 'halfvec(3072) embedding with HNSW index support';
+COMMENT ON TABLE "public"."place_vectors" IS 'Stores halfvec(768) embeddings for places with HNSW indexing for efficient similarity search';
+COMMENT ON COLUMN "public"."place_vectors"."vector" IS 'halfvec(768) embedding with HNSW index support';


### PR DESCRIPTION
## What

Fixes a migration-ordering bug that breaks any **from-scratch database replay** (local dev, CI, disaster-recovery) with:

```
relation "public.place_vectors" does not exist
```

## Why

`1741795200001_convert_place_vectors_768` is timestamped **March 2025** but was actually authored a year later (commit date March 2026 — the timestamp is off by a year). Hasura applies migrations in ascending timestamp order, so it sorts **before** `1757471890000_add_place_vectors_table` (Sep 2025), the migration that actually creates the table. On a fresh replay it runs first and tries to `ALTER` a table that doesn't exist yet.

The correct intended order is:

| Order | Migration | Action |
|------|-----------|--------|
| 1 | `1757471890000_add_place_vectors_table` | creates `place_vectors` as `vector(3072)` |
| 2 | `1757474282000_update_place_vectors_to_halfvec` | → `halfvec(3072)` |
| 3 | `1741795200001_convert_place_vectors_768` | → `halfvec(768)` |

…but #3's timestamp drags it to the front.

## Production impact: none

Prod already applied this migration **in order, against an existing table**, and Hasura never replays applied migrations — so the bad ordering is invisible to a running prod (`place_vectors` is correctly `halfvec(768)` today). The bug only manifests on a fresh-database replay.

This fix is deliberately **in-place** (no migration is renamed / re-versioned), so prod re-runs **nothing** on the next deploy:

- **`1757474282000_update_place_vectors_to_halfvec`** now targets `halfvec(768)` directly. On a fresh replay this is the migration that runs *after* table creation, so the table reaches the correct final shape here.
- **`1741795200001_convert_place_vectors_768`** is wrapped in a guarded `DO` block that is a clean no-op when the table is absent (fresh replay) or already `halfvec(768)` (prod / re-run). The real conversion only runs on the now-unreachable path where the table exists but is still wider than 768.
- Both `down.sql` files were guarded/aligned the same way (the reverse-order rollback was broken by the same timestamp issue).

## Result

On a fresh DB the order is now: `convert_768` (skips) → create table → halfvec migration (→768). Final state — `halfvec(768)` column, HNSW indexes, `halfvec(768)` distance function — is **identical to production**.

## Test plan

- [ ] Fresh local: `docker volume rm cellar-assistant_pgdata_<env>` then `nhost up --apply-seeds` — migrations + seeds apply with no `place_vectors does not exist` error
- [ ] Verify final shape: `psql -c "\d place_vectors"` shows `vector | halfvec(768)`
- [ ] Confirm prod deploy re-runs nothing (no new version numbers introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)